### PR TITLE
ci(mypy): treat proto-tools as an untyped import

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,9 +147,12 @@ module = [
     # Visualization / other
     "pymol.*",
     "vortex.*",
-    # Submodule (proto-tools)
-    "proto_tools.*",
 ]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = ["proto_tools.*"]
+follow_imports = "skip"
 ignore_missing_imports = true
 
 [tool.pydantic-mypy]


### PR DESCRIPTION
Configure mypy to skip following `proto-tools`' types (treat it as an untyped dependency) so type-checking stays focused on proto-language's own code.
