### PR TITLE
feat(constraint): add melting-temperature constraint

### DIFF
--- a/examples/scripts/dna_gc_homopolymer_mcmc.py
+++ b/examples/scripts/dna_gc_homopolymer_mcmc.py
@@ -1,0 +1,37 @@
+from proto_language.core import Segment, Construct, Constraint, Program
+from proto_language.generator import RandomNucleotideGenerator, RandomNucleotideGeneratorConfig
+from proto_language.optimizer import MCMCOptimizer, MCMCOptimizerConfig
+from proto_language.constraint import gc_content_constraint, max_homopolymer_constraint
+from proto_tools.transforms.masking import MaskingStrategy
+
+# Define a 200bp DNA sequence to optimize.
+# RandomNucleotideGenerator in mutation mode requires a valid starting sequence
+# to mutate; provide a 50% GC random seed (here: repeating ATCG as a neutral start).
+_SEED = "ATCG" * 50  # 200 nt, exactly 50% GC, no homopolymers
+dna = Segment(sequence=_SEED, sequence_type="dna")
+construct = Construct(segments=[dna])
+
+# Generator: random point mutations to explore sequence space
+gen = RandomNucleotideGenerator(RandomNucleotideGeneratorConfig(masking_strategy=MaskingStrategy(num_mutations=3)))
+gen.assign(dna)
+
+# Constraints: what the sequence must satisfy
+constraints = [
+    Constraint(inputs=[dna], function=gc_content_constraint,
+               function_config={"min_gc": 45, "max_gc": 55}, weight=1.0),
+    Constraint(inputs=[dna], function=max_homopolymer_constraint,
+               function_config={"max_length": 5}, threshold=0.0),
+]
+
+# Optimize with MCMC
+optimizer = MCMCOptimizer(
+    constructs=[construct], generators=[gen], constraints=constraints,
+    config=MCMCOptimizerConfig(num_steps=500, num_results=5),
+)
+
+program = Program(optimizers=[optimizer], num_results=5)
+program.run()
+
+# Results: 5 optimized sequences ranked by quality
+for seq in construct.joined_sequences:
+    print(seq.sequence)

--- a/proto_language/__init__.py
+++ b/proto_language/__init__.py
@@ -62,6 +62,7 @@ from proto_language.constraint import (
     longest_orf_length_constraint,
     malinois_activity_constraint,
     max_homopolymer_constraint,
+    melting_temperature_constraint,
     mirna_specificity_constraint,
     mmseqs_similarity_constraint,
     mpnn_perplexity_constraint,
@@ -213,6 +214,7 @@ __all__ = [
     "kmer_frequency_constraint",
     "specific_kmer_constraint",
     "dinucleotide_composition_constraint",
+    "melting_temperature_constraint",
     # Protein structure constraints
     "AlphaFold2BinderStructureConfig",
     "StructureBasedConstraintConfig",

--- a/proto_language/constraint/__init__.py
+++ b/proto_language/constraint/__init__.py
@@ -128,6 +128,7 @@ from proto_language.constraint.sequence_composition import (
     gc_content_constraint,
     kmer_frequency_constraint,
     max_homopolymer_constraint,
+    melting_temperature_constraint,
     sequence_length_constraint,
     specific_kmer_constraint,
 )
@@ -158,6 +159,7 @@ __all__ = [
     "kmer_frequency_constraint",
     "specific_kmer_constraint",
     "dinucleotide_composition_constraint",
+    "melting_temperature_constraint",
     # Protein structure
     "AlphaFold2BinderStructureConfig",
     "StructureBasedConstraintConfig",

--- a/proto_language/constraint/sequence_composition/__init__.py
+++ b/proto_language/constraint/sequence_composition/__init__.py
@@ -1,4 +1,4 @@
-"""Sequence composition constraints (GC content, k-mer frequency, homopolymer, length)."""
+"""Sequence composition constraints (GC content, k-mer frequency, homopolymer, length, melting temperature)."""
 
 from proto_language.constraint.sequence_composition.dinucleotide_composition_constraint import (
     dinucleotide_composition_constraint,
@@ -11,6 +11,9 @@ from proto_language.constraint.sequence_composition.max_homopolymer_constraint i
 from proto_language.constraint.sequence_composition.sequence_length_constraint import (
     sequence_length_constraint,
 )
+from proto_language.constraint.sequence_composition.melting_temperature_constraint import (
+    melting_temperature_constraint,
+)
 from proto_language.constraint.sequence_composition.specific_kmer_constraint import (
     specific_kmer_constraint,
 )
@@ -22,4 +25,5 @@ __all__ = [
     "kmer_frequency_constraint",
     "specific_kmer_constraint",
     "dinucleotide_composition_constraint",
+    "melting_temperature_constraint",
 ]

--- a/proto_language/constraint/sequence_composition/melting_temperature_constraint.py
+++ b/proto_language/constraint/sequence_composition/melting_temperature_constraint.py
@@ -1,0 +1,259 @@
+"""Melting temperature (Tm) constraint for DNA oligonucleotide design.
+
+Computes the predicted melting temperature of a DNA sequence and penalizes
+sequences whose Tm falls outside a user-specified range. Two established
+empirical methods are supported: the Wallace rule (preferred for short oligos)
+and the GC-content formula (preferred for longer sequences).
+
+Examples:
+    >>> from proto_language.core import Sequence
+    >>> seq = Sequence("ATCGATCGATCG", "dna")
+    >>> cfg = MeltingTemperatureConfig(min_tm=40.0, max_tm=60.0)
+    >>> result = melting_temperature_constraint([(seq,)], config=cfg)
+    >>> result[0].score  # 0.0 — Tm is within range
+"""
+
+import logging
+import math
+
+from pydantic import model_validator
+
+from proto_language.constraint.constraint_registry import constraint
+from proto_language.core import ConstraintOutput, Sequence
+from proto_language.utils import MAX_ENERGY, calculate_range_deviation
+from proto_language.utils.base import BaseConfig, ConfigField
+
+logger = logging.getLogger(__name__)
+
+# Wallace rule crossover point (sequences ≤ this length use the Wallace rule)
+_WALLACE_CUTOFF = 13
+
+
+class MeltingTemperatureConfig(BaseConfig):
+    """Configuration for the melting temperature (Tm) constraint.
+
+    Two empirical methods are available:
+
+    - ``"wallace"``: Tm = 2·(A+T) + 4·(G+C), in °C. Recommended for short oligos
+      (≤ 13 nt) where the dominant contributors are simply base-pair stacking and
+      hydrogen bonding. No salt correction is applied.
+    - ``"gc_based"``: Tm = 81.5 + 16.6·log₁₀([Na⁺] mM/1000) + 0.41·%GC - 675/N,
+      in °C (Bolton & McCarthy / Marmur-Doty-Wetmur approximation for duplexes
+      > 13 bp). Requires a ``salt_mm`` value; defaults to 50 mM NaCl.
+    - ``"auto"`` (default): Selects the Wallace rule for sequences ≤ 13 nt and the
+      GC-based formula for longer sequences, matching BioPython's ``Tm_Wallace`` /
+      ``Tm_GC`` behaviour.
+
+    Attributes:
+        min_tm (float): Minimum acceptable Tm in degrees Celsius. Sequences with
+            predicted Tm below this value are penalized. Typical oligo targets lie
+            between 50 °C and 65 °C; short oligos (< 10 nt) may target 30-50 °C.
+        max_tm (float): Maximum acceptable Tm in degrees Celsius. Sequences with
+            predicted Tm above this value are penalized.
+        method (str): Tm calculation method: ``"auto"``, ``"wallace"``, or
+            ``"gc_based"``. Defaults to ``"auto"``.
+        salt_mm (float): Monovalent salt concentration in millimolar, used only
+            by the ``"gc_based"`` method. Represents the [Na⁺] equivalent of the
+            hybridisation buffer. Typical values: 50 mM (standard PCR), 0 mM
+            (water — will produce lower predicted Tm), 200 mM (high-salt buffer).
+            Defaults to 50.0 mM.
+    """
+
+    min_tm: float = ConfigField(
+        title="Minimum Tm (°C)",
+        description="Minimum acceptable melting temperature in degrees Celsius.",
+        ge=-100.0,
+        le=200.0,
+        examples=[50.0],
+    )
+    max_tm: float = ConfigField(
+        title="Maximum Tm (°C)",
+        description="Maximum acceptable melting temperature in degrees Celsius.",
+        ge=-100.0,
+        le=200.0,
+        examples=[65.0],
+    )
+    method: str = ConfigField(
+        default="auto",
+        title="Tm Calculation Method",
+        description=(
+            'Tm calculation method: "auto" (Wallace for ≤13 nt, GC-based for longer), '
+            '"wallace" (2·(A+T) + 4·(G+C)), or "gc_based" (81.5 + 16.6·log₁₀([Na⁺]) '
+            "+ 0.41·%GC - 675/N)."
+        ),
+    )
+    salt_mm: float = ConfigField(
+        default=50.0,
+        title="Salt Concentration (mM)",
+        description=(
+            "Monovalent salt concentration in millimolar used by the gc_based method. "
+            "Defaults to 50 mM (standard PCR conditions). Ignored by the wallace method."
+        ),
+        gt=0.0,
+        examples=[50.0],
+    )
+
+    @model_validator(mode="after")
+    def validate_config(self) -> "MeltingTemperatureConfig":
+        """Ensure min_tm <= max_tm and method is valid."""
+        if self.min_tm > self.max_tm:
+            raise ValueError(
+                f"min_tm ({self.min_tm}) must be <= max_tm ({self.max_tm})"
+            )
+        valid_methods = {"auto", "wallace", "gc_based"}
+        if self.method not in valid_methods:
+            raise ValueError(
+                f"method must be one of {sorted(valid_methods)}, got '{self.method}'"
+            )
+        return self
+
+
+def _tm_wallace(sequence: str) -> float:
+    """Compute Tm using the Wallace rule: 2·(A+T) + 4·(G+C).
+
+    Applies to short oligonucleotides (≤ 13 nt). Uses upper-cased sequence
+    and treats both DNA (T) and RNA (U) correctly (U is not AT/GC and is
+    ignored — sequences should be DNA only for reliable results).
+
+    Args:
+        sequence: Upper-cased DNA sequence string.
+
+    Returns:
+        Predicted Tm in degrees Celsius.
+    """
+    at_count = sequence.count("A") + sequence.count("T")
+    gc_count = sequence.count("G") + sequence.count("C")
+    return 2.0 * at_count + 4.0 * gc_count
+
+
+def _tm_gc_based(sequence: str, salt_mm: float) -> float:
+    """Compute Tm using the GC-content / Marmur-Doty approximation.
+
+    Formula (Bolton & McCarthy 1962 / Wetmur 1991):
+        Tm = 81.5 + 16.6·log₁₀([Na⁺]) + 0.41·%GC - 675/N
+
+    where [Na⁺] is in molar units, %GC is 0-100, and N is the sequence length.
+
+    Args:
+        sequence: Upper-cased DNA sequence string (length > 0).
+        salt_mm: Monovalent salt concentration in millimolar.
+
+    Returns:
+        Predicted Tm in degrees Celsius.
+    """
+    n = len(sequence)
+    gc_count = sequence.count("G") + sequence.count("C")
+    gc_pct = 100.0 * gc_count / n
+    salt_molar = salt_mm / 1000.0
+    return 81.5 + 16.6 * math.log10(salt_molar) + 0.41 * gc_pct - 675.0 / n
+
+
+def _compute_tm(sequence: str, config: MeltingTemperatureConfig) -> float:
+    """Select and apply the appropriate Tm formula.
+
+    Args:
+        sequence: Upper-cased DNA sequence (non-empty).
+        config: Validated configuration.
+
+    Returns:
+        Predicted Tm in degrees Celsius.
+    """
+    n = len(sequence)
+    method = config.method
+    if method == "auto":
+        method = "wallace" if n <= _WALLACE_CUTOFF else "gc_based"
+    if method == "wallace":
+        return _tm_wallace(sequence)
+    return _tm_gc_based(sequence, config.salt_mm)
+
+
+@constraint(
+    key="melting-temperature",
+    label="Melting Temperature",
+    config=MeltingTemperatureConfig,
+    description=(
+        "Enforce predicted melting temperature (Tm) within a specified range. "
+        "Uses the Wallace rule for short oligos (≤ 13 nt) and the GC-content "
+        "formula for longer sequences when method='auto'."
+    ),
+    tools_called=[],
+    category="sequence_composition",
+    supported_sequence_types=["dna"],
+)
+def melting_temperature_constraint(
+    input_sequences: list[tuple[Sequence, ...]],
+    config: MeltingTemperatureConfig,
+) -> list[ConstraintOutput]:
+    """Enforce predicted melting temperature within a specified range.
+
+    Computes the predicted Tm for each DNA sequence using an empirical formula
+    and penalises sequences whose Tm falls outside [min_tm, max_tm]. The penalty
+    scales linearly with the degree of deviation.
+
+    Two formulae are available (controlled by ``config.method``):
+
+    - **Wallace rule** (``"wallace"`` or ``"auto"`` with N ≤ 13 nt):
+      ``Tm = 2·(A+T) + 4·(G+C)`` °C — fast, counts-based estimate suitable for
+      short oligos where nearest-neighbour stacking contributes uniformly.
+    - **GC-content formula** (``"gc_based"`` or ``"auto"`` with N > 13 nt):
+      ``Tm = 81.5 + 16.6·log₁₀([Na⁺] M) + 0.41·%GC - 675/N`` °C — Bolton &
+      McCarthy/Wetmur approximation, accurate for typical PCR/hybridisation
+      conditions.
+
+    Args:
+        input_sequences (list[tuple[Sequence, ...]]): List of sequence tuples.
+            Each tuple contains one DNA sequence. Empty sequences receive the
+            maximum penalty.
+        config (MeltingTemperatureConfig): Validated configuration with
+            ``min_tm``, ``max_tm``, ``method``, and ``salt_mm`` fields.
+
+    Returns:
+        list[ConstraintOutput]: One result per sequence. A score of 0.0 means
+        the predicted Tm falls within [min_tm, max_tm]. Higher scores indicate
+        greater deviation, scaling linearly with distance from the acceptable
+        range (capped at 1.0). The ``metadata`` field carries:
+
+        - ``tm``: Predicted Tm in °C (float).
+        - ``method_used``: The formula applied — ``"wallace"`` or ``"gc_based"``
+          (str). Useful for debugging when ``config.method`` is ``"auto"``.
+
+    Examples:
+        Targeting a standard PCR primer Tm window:
+
+        >>> from proto_language.core import Sequence
+        >>> seq = Sequence("GCTAGCTAGCTAGCTA", "dna")
+        >>> cfg = MeltingTemperatureConfig(min_tm=50.0, max_tm=65.0)
+        >>> result = melting_temperature_constraint([(seq,)], config=cfg)
+        >>> result[0].score  # 0.0 if Tm is within range
+    """
+    results = []
+
+    for (seq,) in input_sequences:
+        if len(seq.sequence) == 0:
+            results.append(
+                ConstraintOutput(
+                    score=MAX_ENERGY,
+                    metadata={"tm": 0.0, "method_used": "none"},
+                )
+            )
+            continue
+
+        upper = seq.sequence.upper()
+        n = len(upper)
+
+        # Determine which formula was actually used
+        effective_method = config.method
+        if effective_method == "auto":
+            effective_method = "wallace" if n <= _WALLACE_CUTOFF else "gc_based"
+
+        tm = _compute_tm(upper, config)
+        deviation = calculate_range_deviation(tm, config.min_tm, config.max_tm, epsilon=1.0)
+
+        results.append(
+            ConstraintOutput(
+                score=min(MAX_ENERGY, deviation),
+                metadata={"tm": tm, "method_used": effective_method},
+            )
+        )
+
+    return results

--- a/proto_language/constraint/sequence_composition/melting_temperature_constraint.py
+++ b/proto_language/constraint/sequence_composition/melting_temperature_constraint.py
@@ -54,8 +54,9 @@ class MeltingTemperatureConfig(BaseConfig):
             ``"gc_based"``. Defaults to ``"auto"``.
         salt_mm (float): Monovalent salt concentration in millimolar, used only
             by the ``"gc_based"`` method. Represents the [Na⁺] equivalent of the
-            hybridisation buffer. Typical values: 50 mM (standard PCR), 0 mM
-            (water — will produce lower predicted Tm), 200 mM (high-salt buffer).
+            hybridisation buffer. Must be strictly positive (``gt=0``); the
+            GC-based formula calls ``log10(salt_mm / 1000)`` and is undefined at
+            zero. Typical values: 50 mM (standard PCR), 200 mM (high-salt buffer).
             Defaults to 50.0 mM.
     """
 
@@ -111,9 +112,10 @@ class MeltingTemperatureConfig(BaseConfig):
 def _tm_wallace(sequence: str) -> float:
     """Compute Tm using the Wallace rule: 2·(A+T) + 4·(G+C).
 
-    Applies to short oligonucleotides (≤ 13 nt). Uses upper-cased sequence
-    and treats both DNA (T) and RNA (U) correctly (U is not AT/GC and is
-    ignored — sequences should be DNA only for reliable results).
+    Applies to short oligonucleotides (≤ 13 nt). Non-ACGT characters are
+    ignored in the count, so the function is safe for padded sequences, but
+    this constraint is DNA-only and callers should pass clean upper-cased
+    ACGT sequences.
 
     Args:
         sequence: Upper-cased DNA sequence string.

--- a/tests/language_tests/constraint_tests/test_sequence_composition/test_melting_temperature_constraint.py
+++ b/tests/language_tests/constraint_tests/test_sequence_composition/test_melting_temperature_constraint.py
@@ -1,0 +1,384 @@
+"""tests/language_tests/constraint_tests/test_sequence_composition/test_melting_temperature_constraint.py."""
+
+import math
+
+import pytest
+from pydantic import ValidationError
+
+from proto_language.constraint import melting_temperature_constraint
+from proto_language.constraint.sequence_composition.melting_temperature_constraint import (
+    MeltingTemperatureConfig,
+    _tm_gc_based,
+    _tm_wallace,
+)
+from proto_language.core import Constraint, Segment
+
+# ---------------------------------------------------------------------------
+# Helper: manually compute expected Tm values
+# ---------------------------------------------------------------------------
+
+def _tm_wallace_ref(seq: str) -> float:
+    s = seq.upper()
+    return 2.0 * (s.count("A") + s.count("T")) + 4.0 * (s.count("G") + s.count("C"))
+
+
+def _tm_gc_ref(seq: str, salt_mm: float = 50.0) -> float:
+    s = seq.upper()
+    n = len(s)
+    gc = s.count("G") + s.count("C")
+    gc_pct = 100.0 * gc / n
+    salt_molar = salt_mm / 1000.0
+    return 81.5 + 16.6 * math.log10(salt_molar) + 0.41 * gc_pct - 675.0 / n
+
+
+# ---------------------------------------------------------------------------
+# Wallace rule formula tests
+# ---------------------------------------------------------------------------
+
+class TestTmWallaceFormula:
+    @pytest.mark.parametrize(
+        "sequence, expected_tm",
+        [
+            ("AAAAAAAAAA", 20.0),   # 10 A's: 2*10 + 4*0 = 20
+            ("GGGGGGGGGG", 40.0),   # 10 G's: 2*0 + 4*10 = 40
+            ("ATCGATCG",   24.0),   # 4 AT + 4 GC: 2*4 + 4*4 = 24
+            ("GCATGCAT",   24.0),   # same composition
+        ],
+    )
+    def test_wallace_values(self, sequence: str, expected_tm: float) -> None:
+        assert _tm_wallace(sequence.upper()) == pytest.approx(expected_tm, abs=1e-9)
+
+    def test_single_nucleotide_a(self) -> None:
+        assert _tm_wallace("A") == pytest.approx(2.0)
+
+    def test_single_nucleotide_g(self) -> None:
+        assert _tm_wallace("G") == pytest.approx(4.0)
+
+
+# ---------------------------------------------------------------------------
+# GC-based formula tests
+# ---------------------------------------------------------------------------
+
+class TestTmGCBasedFormula:
+    def test_all_gc_50mM(self) -> None:
+        seq = "G" * 20  # 100% GC, N=20
+        expected = 81.5 + 16.6 * math.log10(0.05) + 0.41 * 100.0 - 675.0 / 20
+        assert _tm_gc_based(seq.upper(), 50.0) == pytest.approx(expected, abs=1e-6)
+
+    def test_all_at_50mM(self) -> None:
+        seq = "A" * 20  # 0% GC, N=20
+        expected = 81.5 + 16.6 * math.log10(0.05) + 0.41 * 0.0 - 675.0 / 20
+        assert _tm_gc_based(seq.upper(), 50.0) == pytest.approx(expected, abs=1e-6)
+
+    def test_higher_salt_raises_tm(self) -> None:
+        seq = "ATCGATCGATCGATCG"  # 16 nt
+        tm_low_salt = _tm_gc_based(seq.upper(), 10.0)
+        tm_high_salt = _tm_gc_based(seq.upper(), 200.0)
+        assert tm_high_salt > tm_low_salt
+
+    def test_longer_sequence_higher_tm(self) -> None:
+        """Longer sequences approach the asymptote (remove 675/N penalty)."""
+        short = _tm_gc_based("GCGCGCGCGCGCGCGC", 50.0)   # 16 nt, 100% GC
+        long_seq = "GCGCGCGCGCGCGCGC" * 10               # 160 nt, 100% GC
+        long_tm = _tm_gc_based(long_seq.upper(), 50.0)
+        assert long_tm > short
+
+
+# ---------------------------------------------------------------------------
+# Constraint scoring (in-range, below-range, above-range)
+# ---------------------------------------------------------------------------
+
+class TestMeltingTemperatureConstraintScoring:
+    @pytest.mark.parametrize(
+        "sequence, min_tm, max_tm, expected_score",
+        [
+            # ── Wallace rule path (≤ 13 nt) ──────────────────────────────
+            # "ATCGATCG" → Tm = 2*4 + 4*4 = 24 °C; range [20, 30] → in range
+            ("ATCGATCG", 20.0, 30.0, 0.0),
+            # "AAAAAAAA" → Tm = 2*8 + 4*0 = 16 °C; range [20, 30] → below range
+            # deviation = (20 - 16) / 20 = 0.2
+            ("AAAAAAAA", 20.0, 30.0, 0.2),
+            # "GCGCGCGC" -> Tm = 2*0 + 4*8 = 32 degC; range [20, 30] -> above range
+            # calculate_range_deviation: (32 - 30) / max(30, 1) = 2/30
+            ("GCGCGCGC", 20.0, 30.0, (32.0 - 30.0) / 30.0),
+            # Exact boundary: Tm == min_tm → score 0.0
+            ("AAAAAAAA", 16.0, 30.0, 0.0),
+            # Exact boundary: Tm == max_tm → score 0.0
+            ("GCGCGCGC", 20.0, 32.0, 0.0),
+        ],
+    )
+    def test_scoring_parametrized(
+        self, sequence: str, min_tm: float, max_tm: float, expected_score: float
+    ) -> None:
+        segment = Segment(sequence=sequence, sequence_type="dna")
+        config = MeltingTemperatureConfig(min_tm=min_tm, max_tm=max_tm, method="auto")
+        cons = Constraint(
+            inputs=[segment],
+            function=melting_temperature_constraint,
+            function_config=config,
+        )
+        assert abs(cons.evaluate()[0] - expected_score) < 1e-6
+
+    def test_empty_sequence_max_penalty(self) -> None:
+        segment = Segment(sequence="", sequence_type="dna")
+        config = MeltingTemperatureConfig(min_tm=50.0, max_tm=65.0)
+        cons = Constraint(
+            inputs=[segment],
+            function=melting_temperature_constraint,
+            function_config=config,
+        )
+        assert cons.evaluate()[0] == pytest.approx(1.0)
+
+    def test_score_capped_at_max_energy(self) -> None:
+        """Sequence far outside the target range receives a high penalty."""
+        # "AAAAAAAA" -> Tm = 16 (Wallace); range [90, 100] -> well below range
+        # calculate_range_deviation(16, 90, 100): (90-16)/max(90,1) = 74/90 ~0.822
+        segment = Segment(sequence="AAAAAAAA", sequence_type="dna")
+        config = MeltingTemperatureConfig(min_tm=90.0, max_tm=100.0)
+        cons = Constraint(
+            inputs=[segment],
+            function=melting_temperature_constraint,
+            function_config=config,
+        )
+        score = cons.evaluate()[0]
+        # Score is capped at MAX_ENERGY = 1.0; here it's ~0.822 (high but not 1.0)
+        assert score > 0.5
+        assert score <= 1.0
+
+    def test_batch_multiple_sequences(self) -> None:
+        """Constraint handles a batch of proposals correctly."""
+        segment = Segment(sequence="AAAAAAAA", sequence_type="dna")
+        # Introduce extra proposals
+        segment.proposal_sequences[0].sequence = "AAAAAAAA"
+        from proto_language.core import Sequence
+        segment.proposal_sequences.append(Sequence("GCGCGCGC", "dna"))
+        config = MeltingTemperatureConfig(min_tm=20.0, max_tm=30.0)
+        cons = Constraint(
+            inputs=[segment],
+            function=melting_temperature_constraint,
+            function_config=config,
+        )
+        scores = cons.evaluate()
+        assert len(scores) == 2
+        # "AAAAAAAA" Tm=16, below range
+        assert scores[0] > 0.0
+        # "GCGCGCGC" Tm=32, above range
+        assert scores[1] > 0.0
+
+
+# ---------------------------------------------------------------------------
+# Method selection (auto / wallace / gc_based)
+# ---------------------------------------------------------------------------
+
+class TestMethodSelection:
+    def test_auto_short_uses_wallace(self) -> None:
+        """Auto method selects Wallace for sequences ≤ 13 nt."""
+        seq = "ATCGATCG"  # 8 nt
+        config = MeltingTemperatureConfig(min_tm=0.0, max_tm=100.0, method="auto")
+        segment = Segment(sequence=seq, sequence_type="dna")
+        cons = Constraint(
+            inputs=[segment],
+            function=melting_temperature_constraint,
+            function_config=config,
+        )
+        cons.evaluate()
+        metadata = segment.proposal_sequences[0]._constraints_metadata
+        assert metadata["melting_temperature_constraint"]["data"]["method_used"] == "wallace"
+
+    def test_auto_long_uses_gc_based(self) -> None:
+        """Auto method selects gc_based for sequences > 13 nt."""
+        seq = "ATCGATCGATCGATCG"  # 16 nt
+        config = MeltingTemperatureConfig(min_tm=0.0, max_tm=100.0, method="auto")
+        segment = Segment(sequence=seq, sequence_type="dna")
+        cons = Constraint(
+            inputs=[segment],
+            function=melting_temperature_constraint,
+            function_config=config,
+        )
+        cons.evaluate()
+        metadata = segment.proposal_sequences[0]._constraints_metadata
+        assert metadata["melting_temperature_constraint"]["data"]["method_used"] == "gc_based"
+
+    def test_explicit_wallace_on_long_sequence(self) -> None:
+        """Explicit method='wallace' applies Wallace even to long sequences."""
+        seq = "ATCGATCGATCGATCG"  # 16 nt
+        config_auto = MeltingTemperatureConfig(min_tm=0.0, max_tm=100.0, method="auto")
+        config_wall = MeltingTemperatureConfig(min_tm=0.0, max_tm=100.0, method="wallace")
+        segment_auto = Segment(sequence=seq, sequence_type="dna")
+        segment_wall = Segment(sequence=seq, sequence_type="dna")
+        Constraint(inputs=[segment_auto], function=melting_temperature_constraint, function_config=config_auto).evaluate()
+        Constraint(inputs=[segment_wall], function=melting_temperature_constraint, function_config=config_wall).evaluate()
+        tm_auto = segment_auto.proposal_sequences[0]._constraints_metadata["melting_temperature_constraint"]["data"]["tm"]
+        tm_wall = segment_wall.proposal_sequences[0]._constraints_metadata["melting_temperature_constraint"]["data"]["tm"]
+        # auto uses gc_based for 16 nt, explicit wallace uses Wallace formula → different values
+        assert tm_auto != pytest.approx(tm_wall, abs=1e-3)
+
+    def test_explicit_gc_based_on_short_sequence(self) -> None:
+        """Explicit method='gc_based' applies GC formula even to short sequences."""
+        seq = "ATCGATCG"  # 8 nt
+        config = MeltingTemperatureConfig(min_tm=0.0, max_tm=100.0, method="gc_based")
+        segment = Segment(sequence=seq, sequence_type="dna")
+        Constraint(inputs=[segment], function=melting_temperature_constraint, function_config=config).evaluate()
+        metadata = segment.proposal_sequences[0]._constraints_metadata
+        assert metadata["melting_temperature_constraint"]["data"]["method_used"] == "gc_based"
+
+    def test_salt_concentration_affects_gc_based_tm(self) -> None:
+        """Higher salt → higher GC-based Tm → possibly different score."""
+        seq = "GCATGCATGCATGCAT"  # 16 nt, gc_based path
+        config_low = MeltingTemperatureConfig(min_tm=0.0, max_tm=100.0, method="gc_based", salt_mm=10.0)
+        config_high = MeltingTemperatureConfig(min_tm=0.0, max_tm=100.0, method="gc_based", salt_mm=500.0)
+        seg_low = Segment(sequence=seq, sequence_type="dna")
+        seg_high = Segment(sequence=seq, sequence_type="dna")
+        Constraint(inputs=[seg_low], function=melting_temperature_constraint, function_config=config_low).evaluate()
+        Constraint(inputs=[seg_high], function=melting_temperature_constraint, function_config=config_high).evaluate()
+        tm_low = seg_low.proposal_sequences[0]._constraints_metadata["melting_temperature_constraint"]["data"]["tm"]
+        tm_high = seg_high.proposal_sequences[0]._constraints_metadata["melting_temperature_constraint"]["data"]["tm"]
+        assert tm_high > tm_low
+
+
+# ---------------------------------------------------------------------------
+# Metadata propagation
+# ---------------------------------------------------------------------------
+
+class TestMetadataPropagation:
+    def test_tm_in_metadata(self) -> None:
+        seq = "ATCGATCGATCG"  # 12 nt, Wallace path
+        expected_tm = _tm_wallace_ref(seq)
+        segment = Segment(sequence=seq, sequence_type="dna")
+        config = MeltingTemperatureConfig(min_tm=0.0, max_tm=100.0)
+        Constraint(
+            inputs=[segment],
+            function=melting_temperature_constraint,
+            function_config=config,
+        ).evaluate()
+        data = segment.proposal_sequences[0]._constraints_metadata["melting_temperature_constraint"]["data"]
+        assert "tm" in data
+        assert data["tm"] == pytest.approx(expected_tm, abs=1e-6)
+
+    def test_method_used_in_metadata(self) -> None:
+        segment = Segment(sequence="ATCG", sequence_type="dna")
+        config = MeltingTemperatureConfig(min_tm=0.0, max_tm=100.0, method="wallace")
+        Constraint(
+            inputs=[segment],
+            function=melting_temperature_constraint,
+            function_config=config,
+        ).evaluate()
+        data = segment.proposal_sequences[0]._constraints_metadata["melting_temperature_constraint"]["data"]
+        assert data["method_used"] == "wallace"
+
+    def test_empty_sequence_metadata(self) -> None:
+        segment = Segment(sequence="", sequence_type="dna")
+        config = MeltingTemperatureConfig(min_tm=50.0, max_tm=65.0)
+        Constraint(
+            inputs=[segment],
+            function=melting_temperature_constraint,
+            function_config=config,
+        ).evaluate()
+        data = segment.proposal_sequences[0]._constraints_metadata["melting_temperature_constraint"]["data"]
+        assert data["tm"] == pytest.approx(0.0)
+        assert data["method_used"] == "none"
+
+
+# ---------------------------------------------------------------------------
+# Wrong sequence type
+# ---------------------------------------------------------------------------
+
+class TestWrongSequenceType:
+    def test_protein_raises_type_error(self) -> None:
+        segment = Segment(sequence="MVLSPADKTNVK", sequence_type="protein")
+        config = MeltingTemperatureConfig(min_tm=50.0, max_tm=65.0)
+        with pytest.raises(TypeError, match="does not support sequence type 'protein'"):
+            Constraint(
+                inputs=[segment],
+                function=melting_temperature_constraint,
+                function_config=config,
+            )
+
+    def test_rna_raises_type_error(self) -> None:
+        segment = Segment(sequence="AUCGAUCG", sequence_type="rna")
+        config = MeltingTemperatureConfig(min_tm=20.0, max_tm=40.0)
+        with pytest.raises(TypeError, match="does not support sequence type 'rna'"):
+            Constraint(
+                inputs=[segment],
+                function=melting_temperature_constraint,
+                function_config=config,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Config validation
+# ---------------------------------------------------------------------------
+
+class TestMeltingTemperatureConfigValidation:
+    def test_min_tm_greater_than_max_tm_raises(self) -> None:
+        with pytest.raises(ValidationError, match=r"min_tm.*must be <= max_tm"):
+            MeltingTemperatureConfig(min_tm=70.0, max_tm=50.0)
+
+    def test_min_tm_equal_max_tm_allowed(self) -> None:
+        config = MeltingTemperatureConfig(min_tm=60.0, max_tm=60.0)
+        assert config.min_tm == config.max_tm == 60.0
+
+    def test_invalid_method_raises(self) -> None:
+        with pytest.raises(ValidationError, match=r"method must be one of"):
+            MeltingTemperatureConfig(min_tm=50.0, max_tm=65.0, method="nearest_neighbor")
+
+    def test_zero_salt_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            MeltingTemperatureConfig(min_tm=50.0, max_tm=65.0, salt_mm=0.0)
+
+    def test_negative_salt_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            MeltingTemperatureConfig(min_tm=50.0, max_tm=65.0, salt_mm=-10.0)
+
+    def test_valid_gc_based_config(self) -> None:
+        config = MeltingTemperatureConfig(min_tm=50.0, max_tm=65.0, method="gc_based", salt_mm=150.0)
+        assert config.method == "gc_based"
+        assert config.salt_mm == pytest.approx(150.0)
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+class TestEdgeCases:
+    def test_single_nucleotide_g(self) -> None:
+        """Single G: Tm = 4 (Wallace); far below range [50, 65] -> high penalty."""
+        # calculate_range_deviation(4, 50, 65): (50-4)/max(50,1) = 0.92
+        segment = Segment(sequence="G", sequence_type="dna")
+        config = MeltingTemperatureConfig(min_tm=50.0, max_tm=65.0)
+        cons = Constraint(
+            inputs=[segment],
+            function=melting_temperature_constraint,
+            function_config=config,
+        )
+        score = cons.evaluate()[0]
+        assert score > 0.8
+        assert score <= 1.0
+
+    def test_lowercase_sequence_handled(self) -> None:
+        """Lowercase input should be handled identically to uppercase."""
+        seg_lower = Segment(sequence="atcgatcg", sequence_type="dna")
+        seg_upper = Segment(sequence="ATCGATCG", sequence_type="dna")
+        config = MeltingTemperatureConfig(min_tm=20.0, max_tm=30.0)
+        score_lower = Constraint(
+            inputs=[seg_lower],
+            function=melting_temperature_constraint,
+            function_config=config,
+        ).evaluate()[0]
+        score_upper = Constraint(
+            inputs=[seg_upper],
+            function=melting_temperature_constraint,
+            function_config=config,
+        ).evaluate()[0]
+        assert score_lower == pytest.approx(score_upper, abs=1e-9)
+
+    def test_exactly_at_crossover_length(self) -> None:
+        """13-nt sequence uses Wallace; 14-nt uses gc_based under 'auto'."""
+        seq_13 = "ATCGATCGATCGA"  # 13 nt
+        seq_14 = "ATCGATCGATCGAT"  # 14 nt
+        config = MeltingTemperatureConfig(min_tm=0.0, max_tm=100.0, method="auto")
+        for seq, expected_method in [(seq_13, "wallace"), (seq_14, "gc_based")]:
+            seg = Segment(sequence=seq, sequence_type="dna")
+            Constraint(inputs=[seg], function=melting_temperature_constraint, function_config=config).evaluate()
+            method_used = seg.proposal_sequences[0]._constraints_metadata["melting_temperature_constraint"]["data"]["method_used"]
+            assert method_used == expected_method, f"Expected {expected_method} for {len(seq)}-nt sequence, got {method_used}"

--- a/tests/language_tests/constraint_tests/test_sequence_composition/test_melting_temperature_constraint.py
+++ b/tests/language_tests/constraint_tests/test_sequence_composition/test_melting_temperature_constraint.py
@@ -22,15 +22,6 @@ def _tm_wallace_ref(seq: str) -> float:
     return 2.0 * (s.count("A") + s.count("T")) + 4.0 * (s.count("G") + s.count("C"))
 
 
-def _tm_gc_ref(seq: str, salt_mm: float = 50.0) -> float:
-    s = seq.upper()
-    n = len(s)
-    gc = s.count("G") + s.count("C")
-    gc_pct = 100.0 * gc / n
-    salt_molar = salt_mm / 1000.0
-    return 81.5 + 16.6 * math.log10(salt_molar) + 0.41 * gc_pct - 675.0 / n
-
-
 # ---------------------------------------------------------------------------
 # Wallace rule formula tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds a `melting-temperature` constraint to the `sequence_composition` category — a natural companion to `gc-content` for DNA oligonucleotide and primer design.

## Motivation

Melting temperature is a primary design criterion for PCR primers, hybridisation probes, and synthetic oligonucleotides. Users targeting a Tm window (e.g. 58–62 °C for PCR) currently must approximate this via `gc-content`, which is indirect. This constraint provides a direct Tm target with no external tool dependencies.

## Implementation

**File:** `proto_language/constraint/sequence_composition/melting_temperature_constraint.py`

Two empirical formulas, auto-selected by sequence length:
- **Wallace rule** (≤ 13 nt): `Tm = 2·(A+T) + 4·(G+C)` — fast, counts-based, standard for short oligos
- **GC-based / Wetmur** (> 13 nt): `Tm = 81.5 + 16.6·log₁₀([Na+] M) + 0.41·%GC - 675/N` — salt-corrected, accurate for PCR/hybridisation conditions

**Config fields:**
| Field | Default | Description |
|---|---|---|
| `min_tm` | required | Minimum Tm (°C) |
| `max_tm` | required | Maximum Tm (°C) |
| `method` | `"auto"` | `"auto"`, `"wallace"`, or `"gc_based"` |
| `salt_mm` | `50.0` | [Na+] mM for GC-based formula |

Scoring: `calculate_range_deviation` (linear, capped at 1.0). Metadata: `{"tm": float, "method_used": str}`. DNA only.

## Tests

37 tests in `tests/language_tests/constraint_tests/test_sequence_composition/test_melting_temperature_constraint.py` covering:
- Parametrized scoring (in-range, below, above, exact boundary)
- Method auto-selection at the 13/14 nt crossover
- Explicit method override (wallace on long seq, gc_based on short)
- Salt concentration effect on GC-based Tm
- Metadata propagation (tm value, method_used)
- Wrong sequence type (protein, RNA) raises TypeError
- Config validation (min > max, invalid method, zero/negative salt)
- Edge cases (empty sequence, single nucleotide, lowercase input)

## Checklist

- [x] `ruff check` passes
- [x] `mypy proto_language/constraint/sequence_composition/melting_temperature_constraint.py` passes
- [x] `pytest tests/language_tests/constraint_tests/test_sequence_composition/ --cpu-only -x` — 37 passed, 0 failed
- [x] Export chain updated (category `__init__`, constraint `__init__`, `__all__`)