### PR TITLE
Derive proposal_source from the generator list when unset

### DIFF
--- a/examples/scripts/cancer_circuit.py
+++ b/examples/scripts/cancer_circuit.py
@@ -442,14 +442,14 @@ def build_binder_stage(args: argparse.Namespace) -> tuple[Program, Segment]:
             threshold=1.0 - AF3_IPTM_MIN,
             label="af3_iptm_filter",
         )
-        # 'existing_results' re-scores the surviving binders (no generation), so no generator.
+        # No generator, so this stage re-scores the surviving binders instead of generating.
         optimizers.append(
             RejectionSamplingOptimizer(
                 constructs=[construct],
                 generators=[],
                 constraints=[af3_filter],
                 config=RejectionSamplingOptimizerConfig(
-                    num_samples=retained, num_results=min(args.num_results, retained), proposal_source="existing_results"
+                    num_samples=retained, num_results=min(args.num_results, retained)
                 ),
             )
         )

--- a/examples/scripts/human_systems_claude/programs/vi_signaling_pathways__b2ar_to_tf_pathway__b2ar_to_tf_pathway.py
+++ b/examples/scripts/human_systems_claude/programs/vi_signaling_pathways__b2ar_to_tf_pathway__b2ar_to_tf_pathway.py
@@ -504,7 +504,6 @@ def create_b2ar_to_tf_pathway_program(creb_dna: str, profile: str = "full") -> t
         config=RejectionSamplingOptimizerConfig(
             num_samples=1,
             num_results=1,
-            proposal_source="existing_results",
             verbose=True,
         ),
     )

--- a/examples/scripts/metal3d_ligandmpnn_ga.py
+++ b/examples/scripts/metal3d_ligandmpnn_ga.py
@@ -239,7 +239,6 @@ def build_program(args: argparse.Namespace) -> tuple[Program, Segment]:
         config=RejectionSamplingOptimizerConfig(
             num_samples=args.population_size,
             num_results=args.population_size,
-            proposal_source="generated",
             proposal_batch_size=args.population_size,
             tracking_interval=1,
             track_proposals=False,
@@ -287,7 +286,6 @@ def build_program(args: argparse.Namespace) -> tuple[Program, Segment]:
         config=RejectionSamplingOptimizerConfig(
             num_samples=1,
             num_results=1,
-            proposal_source="existing_results",
             tracking_interval=1,
             track_proposals=False,
             verbose=args.verbose,

--- a/proto_language/optimizer/rejection_sampling_optimizer.py
+++ b/proto_language/optimizer/rejection_sampling_optimizer.py
@@ -103,8 +103,9 @@ class RejectionSamplingOptimizerConfig(BaseOptimizerConfig):
         num_results (int | None): Number of top sequences to keep and return (lowest
             energy scores). Overrides program-level ``num_results`` if set.
 
-        proposal_source (Literal["generated", "existing_results"]): Whether to
-            generate new proposals or score existing upstream results.
+        proposal_source (Literal["generated", "existing_results"] | None): Whether to
+            generate new proposals or score existing upstream results. If ``None``,
+            derived from whether the optimizer has generators.
 
         proposal_batch_size (int | None): Number of proposal sequences to
             generate and evaluate per internal batch. If ``None``, inferred
@@ -138,10 +139,10 @@ class RejectionSamplingOptimizerConfig(BaseOptimizerConfig):
         title="Design Candidates",
         description="Number of top-scoring candidate designs to retain (lowest energy first). Overrides program count.",
     )
-    proposal_source: Literal["generated", "existing_results"] = ConfigField(
-        default="generated",
+    proposal_source: Literal["generated", "existing_results"] | None = ConfigField(
+        default=None,
         title="Proposal Source",
-        description="Use generated proposals, or rank existing upstream result candidates.",
+        description="Derived from the generator list when unset: generated if generators are present.",
     )
 
     # Advanced parameters
@@ -252,6 +253,8 @@ class RejectionSamplingOptimizer(Optimizer):
             ValueError: If any validation checks fail or num_results cannot be determined.
         """
         self.config = config
+        if config.proposal_source is None:
+            config.proposal_source = "generated" if generators else "existing_results"
         if config.proposal_source == "generated":
             proposal_batch_size = self._resolve_proposal_batch_size(
                 generators=generators,

--- a/tests/language_tests/optimizer_tests/test_rejection_sampling_existing_results.py
+++ b/tests/language_tests/optimizer_tests/test_rejection_sampling_existing_results.py
@@ -46,6 +46,56 @@ def test_rejection_sampling_scores_existing_results_without_generators():
     assert len(optimizer.history[-1]["proposal_results"]) == 1
 
 
+def test_rejection_sampling_derives_existing_results_without_generators():
+    segment = Segment(sequence="AAAA", sequence_type="dna", label="candidate")
+    segment.result_sequences = [
+        Sequence("AAAA", "dna"),
+        Sequence("AAGG", "dna"),
+        Sequence("GGGG", "dna"),
+    ]
+    construct = Construct([segment], label="dna")
+    constraint = Constraint(
+        inputs=[segment],
+        function=gc_content_constraint,
+        function_config={"min_gc": 40, "max_gc": 60},
+    )
+    optimizer = RejectionSamplingOptimizer(
+        constructs=[construct],
+        generators=[],
+        constraints=[constraint],
+        config=RejectionSamplingOptimizerConfig(num_samples=3, num_results=2),
+    )
+
+    assert optimizer.config.proposal_source == "existing_results"
+
+    program = Program(optimizers=[optimizer], num_results=2)
+    program.run()
+
+    assert [seq.sequence for seq in segment.result_sequences] == ["AAGG", "AAAA"]
+    assert optimizer.history[-1]["optimizer"]["proposal_source"] == "existing_results"
+
+
+def test_rejection_sampling_derives_generated_with_generators():
+    segment = Segment(length=10, sequence_type="dna", label="candidate")
+    construct = Construct([segment], label="dna")
+    generator = RandomNucleotideGenerator(RandomNucleotideGeneratorConfig())
+    generator.assign(segment)
+    constraint = Constraint(
+        inputs=[segment],
+        function=gc_content_constraint,
+        function_config={"min_gc": 40, "max_gc": 60},
+    )
+
+    optimizer = RejectionSamplingOptimizer(
+        constructs=[construct],
+        generators=[generator],
+        constraints=[constraint],
+        config=RejectionSamplingOptimizerConfig(num_samples=2, num_results=1),
+    )
+
+    assert optimizer.config.proposal_source == "generated"
+
+
 def test_rejection_sampling_existing_results_allows_later_stage_generated_inputs():
     segment = Segment(length=10, sequence_type="dna", label="generated-upstream")
     construct = Construct([segment], label="dna")
@@ -99,5 +149,5 @@ def test_rejection_sampling_generated_mode_rejects_missing_generators():
             constructs=[construct],
             generators=[],
             constraints=[constraint],
-            config=RejectionSamplingOptimizerConfig(num_samples=1, num_results=1),
+            config=RejectionSamplingOptimizerConfig(proposal_source="generated", num_samples=1, num_results=1),
         )


### PR DESCRIPTION
Fixes proto-bio/proto-language-api#494.

## The problem

A user's three-stage program failed validation on staging with an HTTP 422 from `POST /api/v1/programs/validate`:

```
RejectionSamplingOptimizer requires at least one generator when proposal_source is 'generated'.
```

The final stage folds the best sequence coming out of the preceding GA. It has no generators, which is correct — it generates nothing, it just scores what the previous stage produced. The only thing wrong with the program was that `proposal_source` still held its default of `"generated"`. Setting it to `existing_results` made the program return `{"valid": true, "warnings": []}` with nothing else changed.

## Root cause

`RejectionSamplingOptimizer._validate_optimizer` enforces two guards that are exactly complementary:

```python
if self.config.proposal_source == "generated" and not self.generators:
    raise ValueError(
        "RejectionSamplingOptimizer requires at least one generator when proposal_source is 'generated'."
    )
if self.config.proposal_source == "existing_results" and self.generators:
    raise ValueError(
        "RejectionSamplingOptimizer with proposal_source='existing_results' scores existing sequences and does not accept generators."
    )
```

There is no combination in which the field is a genuine choice:

| generators | only valid `proposal_source` |
|---|---|
| present | `"generated"` |
| absent | `"existing_results"` |

The value is fully determined by `bool(generators)`. It is a derived fact being requested as input — and its default was the one that contradicts an empty generator list, so building a scoring-only stage produced an error for a field the author should never have had to reason about.

**Every program in this repo follows the rule, with no counterexamples**, which is what makes derivation safe rather than merely convenient:

| Program | generators → proposal_source |
|---|---|
| `metal3d_ligandmpnn_ga` | 1 → `generated`; 0 → `existing_results` |
| `metal3d_fampnn_ga` | 1 → `generated` |
| `b2ar_to_tf_pathway` | 0 → `existing_results` (and stage 0: 1 generator, field omitted → correctly defaulted) |
| `cancer_circuit`, `vi_signaling_pathways` | 0 → `existing_results` |

## Why not just delete the field

`BaseConfig` sets `extra="forbid"`, so an unknown key raises rather than being ignored. Removing `proposal_source` would break **every already-saved program that sets it** — seeded `example_programs` rows, users' saved programs in Supabase, and any proto-client script — and would need a data migration coordinated with the deploy. A stale row would fail loudly at load rather than degrade.

The code blast radius is small, but the data blast radius is not. Making the field optional keeps every saved program working and gives a real deprecation path: once nothing writes it, removing it later becomes mechanical.

## The change

### 1. The field becomes optional

```diff
-    proposal_source: Literal["generated", "existing_results"] = ConfigField(
-        default="generated",
+    proposal_source: Literal["generated", "existing_results"] | None = ConfigField(
+        default=None,
         title="Proposal Source",
-        description="Use generated proposals, or rank existing upstream result candidates.",
+        description="Derived from the generator list when unset: generated if generators are present.",
     )
```

This mirrors `CyclingOptimizerConfig.pipeline`, the existing nullable-`Literal` `ConfigField` in this package.

### 2. It is derived in `__init__`

```diff
         self.config = config
+        if config.proposal_source is None:
+            config.proposal_source = "generated" if generators else "existing_results"
         if config.proposal_source == "generated":
             proposal_batch_size = self._resolve_proposal_batch_size(
```

**Why here specifically, and why write back onto the config rather than into a local:**

- The batch-size branch reads the field on the very next line.
- `super().__init__()` (11 lines down) runs `_validate_optimizer()` via `core/optimizer.py:205`.
- `_validate_optimizer()` is re-invoked at runtime on *every* `score_energy()` call (`core/optimizer.py:268`), and both `_initialize_sequence_pools` and `run` branch on the value. A locally-resolved value would leave `self.config.proposal_source` as `None` forever, and `None` silently falls through `!= "existing_results"` into the generated path — a wrong-mode run rather than an error.

Writing the resolved value back onto the config is the established pattern here. The very next statement does exactly this for the same kind of derived-optional field:

```python
self.config.proposal_batch_size = proposal_batch_size
```

and `core/optimizer.py:751` does `config.num_results = num_results`. `BaseConfig` sets `validate_assignment=True`, so the assignment is re-validated against the annotation.

It also means the history snapshot at `_save_proposal_snapshot` keeps emitting a concrete string into the `optimizer.proposal_source` export column — no serialization change, and no `null` appearing in exported run histories.

### 3. Both guards are intentionally left unchanged

An author who explicitly writes `proposal_source="existing_results"` next to a generator still gets the clear error. Derivation only applies when the field is *unset*; explicit values are still validated exactly as before. That is what keeps this a pure widening of accepted input.

## Behavior before / after

```python
RejectionSamplingOptimizer(
    constructs=[construct],
    generators=[],                      # scoring-only stage
    constraints=[af3_filter],
    config=RejectionSamplingOptimizerConfig(num_samples=10, num_results=3),
)
```

- **Before:** `ValueError: RejectionSamplingOptimizer requires at least one generator when proposal_source is 'generated'.` (surfaced to API clients as a 422)
- **After:** constructs successfully; `config.proposal_source` resolves to `"existing_results"`.

Emitted JSON Schema for the field, which is what the UI reads:

```json
{
  "anyOf": [{"enum": ["generated", "existing_results"], "type": "string"}, {"type": "null"}],
  "default": null,
  "title": "Proposal Source",
  "description": "Derived from the generator list when unset: generated if generators are present."
}
```

## What was intentionally NOT changed

- **The two guards** — see above; they are the reason explicit values stay safe.
- **`examples/jsons/*.json`** — these still set `proposal_source` and are left that way deliberately. They double as fixtures proving that saved programs which set the field keep loading.
- **The JSON-emitting dict** in `vi_signaling_pathways__b2ar_to_tf_pathway.py` (~line 790) — it generates the committed JSON fixture above, so it stays in sync with it.
- **Serialization / history metadata** — unchanged by design, since the config carries the resolved value.

## Tests

`tests/language_tests/optimizer_tests/test_rejection_sampling_existing_results.py`:

- **Added** `test_rejection_sampling_derives_existing_results_without_generators` — the exact #494 scenario. Omits `proposal_source`, passes `generators=[]`, asserts the config resolves to `"existing_results"`, then runs the program and asserts it actually scores and ranks the upstream candidates (`["AAGG", "AAAA"]`) and that the history metadata records `"existing_results"`. **This test fails on `main` with the exact error from the issue** — verified before writing the fix.
- **Added** `test_rejection_sampling_derives_generated_with_generators` — the other direction: omitted field plus one generator resolves to `"generated"`.
- **Updated** `test_rejection_sampling_generated_mode_rejects_missing_generators` — it previously relied on the `"generated"` *default* to trigger the guard. Under the new behavior that config derives to `existing_results` and constructs fine, so the test would have silently stopped testing anything. It now passes `proposal_source="generated"` explicitly, which is the case the guard actually exists for.
- `test_rejection_sampling_existing_results_rejects_generators` is unchanged — it already set the value explicitly.

Examples updated to drop the now-redundant field from scoring-only stages (`cancer_circuit.py`, `metal3d_ligandmpnn_ga.py`, `vi_signaling_pathways__b2ar_to_tf_pathway.py`), so they demonstrate the new ergonomics.

## Test plan

```bash
# The two rejection-sampling suites
pytest tests/language_tests/optimizer_tests/test_rejection_sampling_existing_results.py \
       tests/language_tests/optimizer_tests/test_rejection_sampling_optimizer.py --cpu-only -x
# -> 42 passed

# Full CPU suite (covers the docstring / schema-metadata / codebase-consistency gates,
# which this change touches: the Attributes: type must track the annotation, and a
# None default must carry an Optional annotation)
pytest --cpu-only
# -> 3782 passed, 250 skipped

ruff check proto_language tests && ruff format --check   # clean
mypy proto_language/                                     # Success: no issues in 135 source files
python .github/scripts/validate_exports.py               # exit 0
```

### End-to-end check against the real example program

Driven through proto-language-api's actual `POST /api/v1/programs/validate` path using the committed `vi_signaling_pathways__b2ar_to_tf_pathway` example — three stages, the last one `rejection-sampling` with **zero generators**, scoring the previous stage's results. Exactly the shape from the issue.

| final-stage `proposal_source` | pre-fix lib | this branch |
|---|---|---|
| **omitted** | **422** — `requires at least one generator when proposal_source is 'generated'` | **200** |
| explicit `existing_results` | 200 | 200 |
| explicit `generated` + no generators | 422 | 422 |

Row 1 is the reported bug, reproduced and fixed against a real program. Rows 2-3 confirm the guard still fires and saved programs still work.

**This is also the concrete argument for writing the derived value back onto the config.** With the field made optional but the derivation removed, row 1 returns **200** — `None` matches neither guard, so the program validates and then silently takes the *generated* branch at runtime. A nullable field on its own converts a loud 422 into a quiet wrong-mode run.

## Downstream

- **proto-language-api** — no API-layer change needed; it delegates entirely to this package's registry and turns any `ValueError` into the 422. A submodule bump plus a parser regression test follows in a companion PR.
- **proto-ui** — needs a companion PR: its client-side `isExistingResultsRejectionSampling` predicate keys off the literal value, so an omitted field would make it wrongly flag "add a generator" and gate the user before the API is even called. The dropdown is also being hidden, since the field is no longer something an author should answer.
- **proto-docs** — regenerates from this repo's docstrings and field descriptions; the generator drops the `default=` attribute automatically when the default is `None`. No hand edits.

https://claude.ai/code/session_01GfFdmUo533t3gRmsAiuc1X
