### PR TITLE
Bump proto-tools to latest main (47e34af)

### DIFF
--- a/tests/language_tests/constraint_tests/test_sequence_annotation/test_mmseqs_similarity_constraint.py
+++ b/tests/language_tests/constraint_tests/test_sequence_annotation/test_mmseqs_similarity_constraint.py
@@ -10,6 +10,7 @@ from proto_tools import (
     Mmseqs2SearchProteinsOutput,
     Mmseqs2SequenceSearchResult,
     OrfipyOutput,
+    OrfPredictionResult,
 )
 
 from proto_language.constraint import (
@@ -381,12 +382,14 @@ class TestMMseqsSimilarityConstraint:
         orfipy_output = OrfipyOutput(
             metadata={},
             success=True,
-            predicted_orfs=[
-                [
-                    make_orf("gene_1", "MVLSP", 1, 15),
-                    make_orf("gene_2", "MKLLV", 4, 18),
-                    make_orf("gene_3", "MAAAA", 7, 21),
-                ]
+            results=[
+                OrfPredictionResult(
+                    orfs=[
+                        make_orf("gene_1", "MVLSP", 1, 15),
+                        make_orf("gene_2", "MKLLV", 4, 18),
+                        make_orf("gene_3", "MAAAA", 7, 21),
+                    ]
+                )
             ],
         )
 


### PR DESCRIPTION
Moves the `proto-tools` submodule from `5d3dc51` to `47e34af`, picking up four commits:

- `47e34af` Sync proto-bio fork: ESM C SAE tool, helper publishing, env-layer fixes, agent CLI ergonomics (#33)
- `55e2071` Pin dm-haiku for bioemu (#31)
- `f71e272` Remote device integration: `device='proto'/'modal'`, fan-out, and preprocess contract (#30)
- `cbd3801` Add ESM C 6B, relicense ESM family to MIT (#29)

## One test fix was required

`test_unique_orfs_counts_distinct_orfs_with_hits` failed on the new pointer with `assert 0 == 3`. I confirmed it as a genuine bump regression by checking out the old pointer and re-running: it passes on `5d3dc51`, fails on `47e34af`.

Cause is an output-shape change in `OrfipyOutput` upstream. `predicted_orfs` used to be a Pydantic field:

```python
predicted_orfs: list[list[ORF]] = Field(...)
```

It is now a read-only property derived from a new `results: list[OrfPredictionResult]` field, and `iterable_output_field` moved to `results` — the same per-item-model shape the tools repo applies to iterable outputs.

The test built its mock by passing `predicted_orfs=[[...]]` to the constructor. That keyword is no longer a field, so pydantic dropped it silently, leaving `results=[]`. The constraint then found no proteins and took its zero early-return, which is where `0 == 3` came from. The mock now constructs the supported shape:

```python
results=[OrfPredictionResult(orfs=[...])]
```

`OrfPredictionResult` is exported from top-level `proto_tools`, so the import sits with the others.

**No production code needed changing.** Upstream kept `predicted_orfs` working as a property, and every read in `proto_language` goes through it — `mmseqs_similarity_constraint`, `overall_protein_quality_constraint`, `protein_domain_constraint`, and `utils/orf_selection`. This test was the only place in the repo that *constructed* an `OrfipyOutput`, so it was the only breakage.

## Verification

- `pytest --cpu-only` → **3905 passed, 252 skipped, 0 failed** (was 1 failed before the mock fix)
- `ruff check .` clean, `ruff format --check` clean (268 files)
- `mypy proto_language/` → Success, no issues in 139 source files