### PR TITLE
Point the constraint reference card at the page that exists

### DIFF
--- a/guides/using-constraints.ipynb
+++ b/guides/using-constraints.ipynb
@@ -444,7 +444,7 @@
     "  <Card title=\"Constraints concept\" icon=\"book\" href=\"/language/concepts/constraints\">\n",
     "    How constraints relate to the rest of the model.\n",
     "  </Card>\n",
-    "  <Card title=\"Constraint reference\" icon=\"list\" href=\"/language/constraints/gc-content-constraint\">\n",
+    "  <Card title=\"Constraint reference\" icon=\"list\" href=\"/language/constraints/gc-content\">\n",
     "    The complete catalog of built-in constraints.\n",
     "  </Card>\n",
     "</CardGroup>"


### PR DESCRIPTION
The "Constraint reference" card in the using-constraints guide links `/language/constraints/gc-content-constraint`. That slug has never existed in proto-docs. The registered key is `gc-content` (`proto_language/constraint/sequence_composition/gc_content_constraint.py:50`), so the generated page is `gc-content.mdx`.

## Why it belongs here and not in proto-docs

`guides/using-constraints.ipynb` is the source for `language/guides/using-constraints.mdx` on the docs site; proto-docs builds those pages with `generate_language_guides()`. The dead link was therefore republished on every sync.

It was patched once in the generated MDX downstream ([proto-docs#119](https://github.com/proto-bio/proto-docs/pull/119)), and the very next regeneration reverted it, which is how the wrong layer got found. proto-docs `CLAUDE.md` listed `language/guides/*.mdx` under hand-written, which is what pointed at the wrong layer; that is being corrected in the proto-docs bump PR.

## Change

One character-level edit in cell 17. Notebook still parses, 18 cells, no output cells touched.

```diff
-  <Card title="Constraint reference" icon="list" href="/language/constraints/gc-content-constraint">
+  <Card title="Constraint reference" icon="list" href="/language/constraints/gc-content">
```

Once this merges, the proto-docs bump re-pins and the docs link check goes green.