### PR TITLE
feat: deploy Modal tools on first use

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,15 @@ Setup lives in the tool layer, in the separate [evo-design/proto-tools](https://
 - [Modal setup guide](https://github.com/evo-design/proto-tools/blob/main/proto_tools/modal/README.md) — account setup, deploying a tool, and costs.
 - [Step 4 of the proto-tools README](https://github.com/evo-design/proto-tools#step-4-remote-compute-optional-) — the same step in context.
 
-Once a tool is deployed, set `device="modal"` on the constraint or generator config that uses it.
+To run an optimization remotely without deploying the full catalog, opt in at the program level:
+
+```python
+program.run(device="modal")
+```
+
+Each missing app is deployed only when its tool is actually called. Unused tools are not deployed,
+and subsequent calls reuse the existing app. Because first-use deployment builds and warms the app,
+both that warmup and the requested call are billed to your Modal account.
 
 > [!TIP]
 > Setup is complete. See the [Quickstart](#quickstart) to run a program from end to end.

--- a/README.md
+++ b/README.md
@@ -71,10 +71,8 @@ To run an optimization remotely without deploying the full catalog, opt in at th
 program.run(device="modal")
 ```
 
-The optimization loop, CPU tools, and tools declared local-only continue to run locally. Each missing
-deployable GPU app is deployed only when its tool is actually called; unused GPU tools are not
-deployed, and subsequent calls reuse the existing app. Because first-use deployment builds and warms
-the app, both that warmup and the requested call are billed to your Modal account.
+Models and tools that require modal compute will be deployed automatically upon the first run of your
+program.
 
 > [!TIP]
 > Setup is complete. See the [Quickstart](#quickstart) to run a program from end to end.

--- a/README.md
+++ b/README.md
@@ -71,9 +71,10 @@ To run an optimization remotely without deploying the full catalog, opt in at th
 program.run(device="modal")
 ```
 
-Each missing app is deployed only when its tool is actually called. Unused tools are not deployed,
-and subsequent calls reuse the existing app. Because first-use deployment builds and warms the app,
-both that warmup and the requested call are billed to your Modal account.
+The optimization loop and CPU tools continue to run locally. Each missing GPU app is deployed only
+when its tool is actually called; unused GPU tools are not deployed, and subsequent calls reuse the
+existing app. Because first-use deployment builds and warms the app, both that warmup and the
+requested call are billed to your Modal account.
 
 > [!TIP]
 > Setup is complete. See the [Quickstart](#quickstart) to run a program from end to end.

--- a/README.md
+++ b/README.md
@@ -71,10 +71,10 @@ To run an optimization remotely without deploying the full catalog, opt in at th
 program.run(device="modal")
 ```
 
-The optimization loop and CPU tools continue to run locally. Each missing GPU app is deployed only
-when its tool is actually called; unused GPU tools are not deployed, and subsequent calls reuse the
-existing app. Because first-use deployment builds and warms the app, both that warmup and the
-requested call are billed to your Modal account.
+The optimization loop, CPU tools, and tools declared local-only continue to run locally. Each missing
+deployable GPU app is deployed only when its tool is actually called; unused GPU tools are not
+deployed, and subsequent calls reuse the existing app. Because first-use deployment builds and warms
+the app, both that warmup and the requested call are billed to your Modal account.
 
 > [!TIP]
 > Setup is complete. See the [Quickstart](#quickstart) to run a program from end to end.

--- a/proto_language/core/program.py
+++ b/proto_language/core/program.py
@@ -157,10 +157,9 @@ class Program:
                 always takes priority.
             verbose (bool): If True, print detailed energy score calculations for each constraint
                      for all optimizers.
-            compute (ToolPool | None): Context manager for tool execution. If None,
-                auto-detects: nullcontext when external dispatch is configured (cloud SDK
-                backend or a deployment dispatch backend), else ToolPool()
-                (symmetric across GPU and CPU-only hosts).
+            compute (ToolPool | None): Context manager for tool execution. If None, resolved
+                when the run starts: nullcontext when tool calls are routed to Modal, else
+                ToolPool() (symmetric across GPU and CPU-only hosts).
             seed (int | None): Random seed for fully reproducible optimization. When set,
                 derives unique optimizer config seeds, overriding optimizer-level
                 seeds. Same seed + same input = same output.
@@ -173,21 +172,6 @@ class Program:
             raise ValueError(
                 "Program requires at least one Optimizer (got empty list); pass optimizers=[opt1, opt2, ...] to chain stages"
             )
-
-        if compute is None:
-            from contextlib import nullcontext
-
-            from proto_tools.tools.tool_registry import ToolRegistry
-            from proto_tools.utils.tool_pool import ToolPool
-
-            # A local ToolPool bypasses cloud dispatch, so skip it when external dispatch is configured.
-            has_backend = ToolRegistry.dispatch_backend_configured()
-            if has_backend:
-                logger.debug("External dispatch configured; GPU tools will route to the hosted service.")
-                compute = nullcontext()
-            else:
-                # Symmetric across GPU and CPU-only hosts.
-                compute = ToolPool()
 
         self.compute = compute
 
@@ -456,15 +440,7 @@ class Program:
             device (Literal["modal"] | None): Route GPU tool calls to Modal. Missing
                 apps deploy when first called; CPU tools continue to run locally.
         """
-        if device not in {None, "modal"}:
-            raise ValueError(f"Unsupported program device {device!r}; expected 'modal' or None.")
-        dispatch_context: AbstractContextManager[None]
-        if device == "modal":
-            from proto_language.modal import on_demand_modal_tools
-
-            dispatch_context = on_demand_modal_tools()
-        else:
-            dispatch_context = nullcontext()
+        dispatch_context = self._dispatch_context(device)
 
         # Reset stage tracking for fresh run
         self.current_stage = 0
@@ -513,17 +489,7 @@ class Program:
             >>> results = program.get_stage_results(0)  # Access results
             >>> program.run_stage(1)  # Run second optimizer
         """
-        if device not in {None, "modal"}:
-            raise ValueError(f"Unsupported program device {device!r}; expected 'modal' or None.")
-        dispatch_context: AbstractContextManager[None]
-        if device == "modal":
-            from proto_language.modal import on_demand_modal_tools
-
-            dispatch_context = on_demand_modal_tools()
-        else:
-            dispatch_context = nullcontext()
-
-        with dispatch_context, self._enter_compute():
+        with self._dispatch_context(device), self._enter_compute():
             self._validate_program()
             if stage_index < 0 or stage_index >= len(self.optimizers):
                 raise IndexError(f"Stage index {stage_index} out of range (0-{len(self.optimizers) - 1}).")
@@ -563,6 +529,48 @@ class Program:
             self._stage_results.append(stage_result)
             self.current_stage = stage_index + 1
 
+    @staticmethod
+    def _dispatch_context(device: Literal["modal"] | None) -> AbstractContextManager[None]:
+        """Return the tool-dispatch context for a run or stage.
+
+        Args:
+            device (Literal["modal"] | None): Target for GPU tool calls.
+
+        Returns:
+            AbstractContextManager[None]: Modal dispatch context, or a no-op for local runs.
+
+        Raises:
+            ValueError: If device is not 'modal' or None.
+        """
+        if device is None:
+            return nullcontext()
+        if device != "modal":
+            raise ValueError(f"Unsupported program device {device!r}; expected 'modal' or None.")
+        from proto_language.modal import on_demand_modal_tools
+
+        return on_demand_modal_tools()
+
+    def _resolve_compute(self) -> AbstractContextManager[Any]:
+        """Return the compute context, choosing a local pool only when tools run locally.
+
+        Resolved at entry rather than construction so Modal routing configured by
+        ``run(device=...)`` is visible here, and no local ToolPool claims GPUs it will not use.
+        """
+        compute: AbstractContextManager[Any]
+        if self.compute is not None:
+            compute = self.compute
+            return compute
+
+        from proto_tools.tools.tool_registry import ToolRegistry
+        from proto_tools.utils.tool_pool import ToolPool
+
+        if ToolRegistry.dispatch_backend_configured():
+            logger.debug("Modal routing active; GPU tools will run remotely instead of in a local pool.")
+            return nullcontext()
+        # Symmetric across GPU and CPU-only hosts.
+        compute = ToolPool()
+        return compute
+
     @contextmanager
     def _enter_compute(self) -> Iterator[None]:
         """Enter compute context if not already active, otherwise no-op.
@@ -575,7 +583,7 @@ class Program:
         if _active_pool.get() is not None:
             yield
         else:
-            with self.compute:
+            with self._resolve_compute():
                 yield
 
     @contextmanager

--- a/proto_language/core/program.py
+++ b/proto_language/core/program.py
@@ -47,7 +47,7 @@ import logging
 import math
 import time
 from collections.abc import Iterator
-from contextlib import contextmanager
+from contextlib import AbstractContextManager, contextmanager, nullcontext
 from pathlib import Path
 from typing import Any, Literal
 
@@ -446,12 +446,26 @@ class Program:
                 seqs = [seg["sequence"] for seg in construct["segments"]]
                 logger.debug(f"    {construct['label']}: {' | '.join(seqs)}")
 
-    def run(self) -> None:
+    def run(self, *, device: Literal["modal"] | None = None) -> None:
         """Execute the sequence optimization process for all optimizers sequentially.
 
         Each optimizer builds on the results of the previous one. State automatically
         persists between optimizers through the shared construct objects.
+
+        Args:
+            device (Literal["modal"] | None): Route every tool call to Modal. Missing
+                apps deploy when first called; tools that are never called deploy nothing.
         """
+        if device not in {None, "modal"}:
+            raise ValueError(f"Unsupported program device {device!r}; expected 'modal' or None.")
+        dispatch_context: AbstractContextManager[None]
+        if device == "modal":
+            from proto_language.modal import on_demand_modal_tools
+
+            dispatch_context = on_demand_modal_tools()
+        else:
+            dispatch_context = nullcontext()
+
         # Reset stage tracking for fresh run
         self.current_stage = 0
         self._stage_results = []
@@ -466,11 +480,16 @@ class Program:
 
         seed_str = f", seed={self.seed}" if self.seed is not None else ""
         logger.info(f"Running program: {len(self.optimizers)} stage(s), num_results={self.num_results}{seed_str}")
-        with self._enter_compute(), self._log_duration("Program"):
+        with dispatch_context, self._enter_compute(), self._log_duration("Program"):
             for optimizer_stage_idx in range(len(self.optimizers)):
                 self.run_stage(optimizer_stage_idx)
 
-    def run_stage(self, stage_index: int) -> None:
+    def run_stage(
+        self,
+        stage_index: int,
+        *,
+        device: Literal["modal"] | None = None,
+    ) -> None:
         """Execute a specific optimization stage.
 
         Allows running optimizers one at a time with inspection of results between
@@ -482,6 +501,7 @@ class Program:
 
         Args:
             stage_index (int): Zero-based index of the optimizer stage to run.
+            device (Literal["modal"] | None): Route this stage's actual tool calls to Modal.
 
         Raises:
             IndexError: If stage_index is out of range.
@@ -493,7 +513,17 @@ class Program:
             >>> results = program.get_stage_results(0)  # Access results
             >>> program.run_stage(1)  # Run second optimizer
         """
-        with self._enter_compute():
+        if device not in {None, "modal"}:
+            raise ValueError(f"Unsupported program device {device!r}; expected 'modal' or None.")
+        dispatch_context: AbstractContextManager[None]
+        if device == "modal":
+            from proto_language.modal import on_demand_modal_tools
+
+            dispatch_context = on_demand_modal_tools()
+        else:
+            dispatch_context = nullcontext()
+
+        with dispatch_context, self._enter_compute():
             self._validate_program()
             if stage_index < 0 or stage_index >= len(self.optimizers):
                 raise IndexError(f"Stage index {stage_index} out of range (0-{len(self.optimizers) - 1}).")
@@ -542,7 +572,9 @@ class Program:
         """
         from proto_tools.utils.tool_pool import _active_pool
 
-        if _active_pool.get() is not None:
+        from proto_language.modal import modal_dispatch_active
+
+        if modal_dispatch_active() or _active_pool.get() is not None:
             yield
         else:
             with self.compute:

--- a/proto_language/core/program.py
+++ b/proto_language/core/program.py
@@ -453,8 +453,8 @@ class Program:
         persists between optimizers through the shared construct objects.
 
         Args:
-            device (Literal["modal"] | None): Route every tool call to Modal. Missing
-                apps deploy when first called; tools that are never called deploy nothing.
+            device (Literal["modal"] | None): Route GPU tool calls to Modal. Missing
+                apps deploy when first called; CPU tools continue to run locally.
         """
         if device not in {None, "modal"}:
             raise ValueError(f"Unsupported program device {device!r}; expected 'modal' or None.")
@@ -501,7 +501,7 @@ class Program:
 
         Args:
             stage_index (int): Zero-based index of the optimizer stage to run.
-            device (Literal["modal"] | None): Route this stage's actual tool calls to Modal.
+            device (Literal["modal"] | None): Route this stage's GPU tool calls to Modal.
 
         Raises:
             IndexError: If stage_index is out of range.
@@ -572,9 +572,7 @@ class Program:
         """
         from proto_tools.utils.tool_pool import _active_pool
 
-        from proto_language.modal import modal_dispatch_active
-
-        if modal_dispatch_active() or _active_pool.get() is not None:
+        if _active_pool.get() is not None:
             yield
         else:
             with self.compute:

--- a/proto_language/modal.py
+++ b/proto_language/modal.py
@@ -48,8 +48,8 @@ def on_demand_modal_tools() -> Iterator[None]:
     """Route GPU tool calls to Modal and deploy only missing apps they reach.
 
     Entering this context is the cost-bearing approval: a missing app may build
-    and run its normal warmup. CPU tools continue to run locally, and GPU tools
-    that are never called deploy nothing.
+    and run its normal warmup. CPU and local-only tools continue to run locally,
+    and deployable GPU tools that are never called deploy nothing.
     """
     from proto_tools.modal.app import resolve_environment
     from proto_tools.tools import ToolRegistry
@@ -64,7 +64,8 @@ def on_demand_modal_tools() -> Iterator[None]:
         # threads and tasks on their existing execution path.
         if not _ACTIVE.get():
             return None
-        if not ToolRegistry.get(key).uses_gpu:
+        spec = ToolRegistry.get(key)
+        if not spec.uses_gpu or spec.local_only is not None:
             return None
         return _dispatch_with_deployment(key, inputs, config, resolved_environment)
 

--- a/proto_language/modal.py
+++ b/proto_language/modal.py
@@ -1,0 +1,79 @@
+"""Run-scoped, on-demand Modal dispatch for language optimizations."""
+
+import contextvars
+import hashlib
+import os
+import tempfile
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+from filelock import FileLock
+
+_ACTIVE = contextvars.ContextVar("proto_language_modal_dispatch_active", default=False)
+
+
+def modal_dispatch_active() -> bool:
+    """Return whether this execution context routes language tools to Modal."""
+    return _ACTIVE.get()
+
+
+def _deployment_lock(app_name: str, environment: str) -> FileLock:
+    """Coordinate the first deployment across local processes without storing credentials."""
+    workspace = os.environ.get("MODAL_TOKEN_ID", "default-profile")
+    identity = hashlib.sha256(f"{workspace}\0{environment}\0{app_name}".encode()).hexdigest()
+    root = Path(tempfile.gettempdir()) / "proto-language-modal-deployments"
+    root.mkdir(parents=True, exist_ok=True)
+    return FileLock(root / f"{identity}.lock")
+
+
+def _dispatch_with_deployment(key: str, inputs: Any, config: Any, environment: str) -> Any:
+    """Dispatch one actual tool call, deploying only its missing app before retrying."""
+    from proto_tools.modal import ToolNotDeployedError, dispatch_to_modal
+    from proto_tools.modal.deploy import deploy_app
+
+    try:
+        return dispatch_to_modal(key, inputs, config, environment=environment)
+    except ToolNotDeployedError as exc:
+        app_name = exc.app_name
+
+    with _deployment_lock(app_name, environment):
+        # Another process may have completed the same app while this call waited.
+        try:
+            return dispatch_to_modal(key, inputs, config, environment=environment)
+        except ToolNotDeployedError:
+            if not deploy_app(app_name, environment):
+                raise RuntimeError(f"Failed to deploy Modal app {app_name!r} for tool {key!r}.") from None
+        return dispatch_to_modal(key, inputs, config, environment=environment)
+
+
+@contextmanager
+def on_demand_modal_tools() -> Iterator[None]:
+    """Route actual tool calls to Modal and deploy only missing apps they reach.
+
+    Entering this context is the cost-bearing approval: a missing app may build
+    and run its normal warmup. Calls that never occur deploy nothing.
+    """
+    from proto_tools.modal.app import resolve_environment
+    from proto_tools.tools import ToolRegistry
+
+    if ToolRegistry.dispatch_backend_configured():
+        raise RuntimeError("Cannot enable on-demand Modal tools while another dispatch backend is configured.")
+
+    resolved_environment = resolve_environment(None)
+
+    def dispatch(key: str, inputs: Any, config: Any) -> Any:
+        # ToolRegistry's hook is process-global; the ContextVar keeps unrelated
+        # threads and tasks on their existing execution path.
+        if not _ACTIVE.get():
+            return None
+        return _dispatch_with_deployment(key, inputs, config, resolved_environment)
+
+    ToolRegistry.configure_dispatch_backend(dispatch)
+    token = _ACTIVE.set(True)
+    try:
+        yield
+    finally:
+        ToolRegistry.clear_dispatch_backend()
+        _ACTIVE.reset(token)

--- a/proto_language/modal.py
+++ b/proto_language/modal.py
@@ -14,11 +14,6 @@ from filelock import FileLock
 _ACTIVE = contextvars.ContextVar("proto_language_modal_dispatch_active", default=False)
 
 
-def modal_dispatch_active() -> bool:
-    """Return whether this execution context routes language tools to Modal."""
-    return _ACTIVE.get()
-
-
 def _deployment_lock(app_name: str, environment: str) -> FileLock:
     """Coordinate the first deployment across local processes without storing credentials."""
     workspace = os.environ.get("MODAL_TOKEN_ID", "default-profile")
@@ -50,10 +45,11 @@ def _dispatch_with_deployment(key: str, inputs: Any, config: Any, environment: s
 
 @contextmanager
 def on_demand_modal_tools() -> Iterator[None]:
-    """Route actual tool calls to Modal and deploy only missing apps they reach.
+    """Route GPU tool calls to Modal and deploy only missing apps they reach.
 
     Entering this context is the cost-bearing approval: a missing app may build
-    and run its normal warmup. Calls that never occur deploy nothing.
+    and run its normal warmup. CPU tools continue to run locally, and GPU tools
+    that are never called deploy nothing.
     """
     from proto_tools.modal.app import resolve_environment
     from proto_tools.tools import ToolRegistry
@@ -67,6 +63,8 @@ def on_demand_modal_tools() -> Iterator[None]:
         # ToolRegistry's hook is process-global; the ContextVar keeps unrelated
         # threads and tasks on their existing execution path.
         if not _ACTIVE.get():
+            return None
+        if not ToolRegistry.get(key).uses_gpu:
             return None
         return _dispatch_with_deployment(key, inputs, config, resolved_environment)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ dependencies = [
     "tqdm",
     "openpyxl",
     "docstring-parser",  # Extract per-field docs from Google-style config docstrings
+    "filelock>=3.0",  # Coordinate first-use Modal deployments across local processes
 ]
 
 [project.urls]

--- a/tests/language_tests/test_modal_planning.py
+++ b/tests/language_tests/test_modal_planning.py
@@ -207,3 +207,69 @@ def test_program_modal_scope_preserves_local_tool_pool(monkeypatch: pytest.Monke
     assert observed == [True]
     assert compute_events == ["enter", "exit"]
     assert not ToolRegistry.dispatch_backend_configured()
+
+
+def test_modal_run_does_not_create_local_tool_pool(monkeypatch: pytest.MonkeyPatch) -> None:
+    """device='modal' routes GPU work remotely, so no local ToolPool should be allocated."""
+    from unittest.mock import patch
+
+    from proto_language.constraint import ConstraintRegistry
+    from proto_language.core import Construct, Program, Segment
+    from proto_language.generator import RandomNucleotideGenerator, RandomNucleotideGeneratorConfig
+    from proto_language.optimizer import RejectionSamplingOptimizer, RejectionSamplingOptimizerConfig
+
+    segment = Segment(sequence="ATGC", sequence_type="dna")
+    generator = RandomNucleotideGenerator(RandomNucleotideGeneratorConfig())
+    generator.assign(segment)
+    constraint = ConstraintRegistry.create(
+        key="gc-content",
+        segments=[segment],
+        config_dict={"min_gc": 0, "max_gc": 100},
+    )
+    optimizer = RejectionSamplingOptimizer(
+        constructs=[Construct([segment])],
+        generators=[generator],
+        constraints=[constraint],
+        config=RejectionSamplingOptimizerConfig(num_samples=1, num_results=1),
+    )
+    program = Program([optimizer], num_results=1)
+
+    monkeypatch.setattr("proto_tools.modal.app.resolve_environment", lambda value: value or "proto-env")
+    resolved: list[object] = []
+    monkeypatch.setattr(program, "run_stage", lambda _stage: resolved.append(program._resolve_compute()))
+
+    with patch("proto_tools.utils.tool_pool.ToolPool") as mock_pool_cls:
+        program.run(device="modal")
+        mock_pool_cls.assert_not_called()
+
+    assert isinstance(resolved[0], nullcontext)
+
+
+def test_local_run_still_creates_tool_pool() -> None:
+    """Without a dispatch backend the local pool is still what runs tools."""
+    from unittest.mock import patch
+
+    from proto_language.constraint import ConstraintRegistry
+    from proto_language.core import Construct, Program, Segment
+    from proto_language.generator import RandomNucleotideGenerator, RandomNucleotideGeneratorConfig
+    from proto_language.optimizer import RejectionSamplingOptimizer, RejectionSamplingOptimizerConfig
+
+    segment = Segment(sequence="ATGC", sequence_type="dna")
+    generator = RandomNucleotideGenerator(RandomNucleotideGeneratorConfig())
+    generator.assign(segment)
+    constraint = ConstraintRegistry.create(
+        key="gc-content",
+        segments=[segment],
+        config_dict={"min_gc": 0, "max_gc": 100},
+    )
+    optimizer = RejectionSamplingOptimizer(
+        constructs=[Construct([segment])],
+        generators=[generator],
+        constraints=[constraint],
+        config=RejectionSamplingOptimizerConfig(num_samples=1, num_results=1),
+    )
+    program = Program([optimizer], num_results=1)
+
+    with patch("proto_tools.utils.tool_pool.ToolPool") as mock_pool_cls:
+        assert program._resolve_compute() is mock_pool_cls.return_value
+        mock_pool_cls.assert_called_once()

--- a/tests/language_tests/test_modal_planning.py
+++ b/tests/language_tests/test_modal_planning.py
@@ -79,6 +79,38 @@ def test_context_installs_and_restores_one_dispatch_backend(monkeypatch: pytest.
     assert not ToolRegistry.dispatch_backend_configured()
 
 
+@pytest.mark.parametrize("tool_key", ["random-nucleotide-sample", "random-protein-sample"])
+def test_context_leaves_cpu_tools_local(monkeypatch: pytest.MonkeyPatch, tool_key: str) -> None:
+    from proto_tools.tools import ToolRegistry
+
+    monkeypatch.setattr("proto_tools.modal.app.resolve_environment", lambda value: value or "proto-env")
+    monkeypatch.setattr(
+        "proto_language.modal._dispatch_with_deployment",
+        lambda *_args: pytest.fail(f"CPU tool {tool_key!r} was routed to Modal"),
+    )
+
+    with on_demand_modal_tools():
+        backend = ToolRegistry._dispatch_backend
+        assert backend is not None
+        assert backend(tool_key, object(), object()) is None
+
+
+def test_context_routes_gpu_tools_to_modal(monkeypatch: pytest.MonkeyPatch) -> None:
+    from proto_tools.tools import ToolRegistry
+
+    expected = object()
+    monkeypatch.setattr("proto_tools.modal.app.resolve_environment", lambda value: value or "proto-env")
+    monkeypatch.setattr(
+        "proto_language.modal._dispatch_with_deployment",
+        lambda *args: expected if args[0] == "esm2-sample" else pytest.fail(f"unexpected tool: {args[0]}"),
+    )
+
+    with on_demand_modal_tools():
+        backend = ToolRegistry._dispatch_backend
+        assert backend is not None
+        assert backend("esm2-sample", object(), object()) is expected
+
+
 def test_context_does_not_overwrite_an_existing_backend(monkeypatch: pytest.MonkeyPatch) -> None:
     from proto_tools.tools import ToolRegistry
 
@@ -114,7 +146,7 @@ def test_unrelated_thread_is_not_captured_by_modal_scope(monkeypatch: pytest.Mon
     assert result is None
 
 
-def test_program_modal_scope_skips_local_tool_pool(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_program_modal_scope_preserves_local_tool_pool(monkeypatch: pytest.MonkeyPatch) -> None:
     from proto_tools.tools import ToolRegistry
 
     from proto_language.constraint import ConstraintRegistry
@@ -138,14 +170,17 @@ def test_program_modal_scope_skips_local_tool_pool(monkeypatch: pytest.MonkeyPat
     )
     program = Program([optimizer], num_results=1)
 
-    class RefusingCompute:
+    compute_events: list[str] = []
+
+    class TrackingCompute:
         def __enter__(self):
-            pytest.fail("device='modal' entered the local ToolPool")
+            compute_events.append("enter")
+            return self
 
         def __exit__(self, *_args):
-            return None
+            compute_events.append("exit")
 
-    program.compute = RefusingCompute()
+    program.compute = TrackingCompute()
     observed: list[bool] = []
     monkeypatch.setattr("proto_tools.modal.app.resolve_environment", lambda value: value or "proto-env")
     monkeypatch.setattr(
@@ -155,4 +190,5 @@ def test_program_modal_scope_skips_local_tool_pool(monkeypatch: pytest.MonkeyPat
     program.run(device="modal")
 
     assert observed == [True]
+    assert compute_events == ["enter", "exit"]
     assert not ToolRegistry.dispatch_backend_configured()

--- a/tests/language_tests/test_modal_planning.py
+++ b/tests/language_tests/test_modal_planning.py
@@ -1,0 +1,158 @@
+"""Focused tests for language-owned, on-demand Modal deployment."""
+
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import nullcontext
+
+import pytest
+
+from proto_language.modal import _dispatch_with_deployment, on_demand_modal_tools
+
+
+def test_current_tool_dispatches_without_deploying(monkeypatch: pytest.MonkeyPatch) -> None:
+    expected = object()
+    deployed: list[str] = []
+    monkeypatch.setattr("proto_tools.modal.dispatch_to_modal", lambda *_args, **_kwargs: expected)
+    monkeypatch.setattr("proto_tools.modal.deploy.deploy_app", lambda app, _env: deployed.append(app) or True)
+
+    result = _dispatch_with_deployment("boltz2-prediction", object(), object(), "proto-env")
+
+    assert result is expected
+    assert deployed == []
+
+
+def test_missing_tool_deploys_only_its_app_then_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    from proto_tools.modal import ToolNotDeployedError
+
+    calls = 0
+    deployed: list[tuple[str, str]] = []
+    expected = object()
+
+    def dispatch(*_args, **_kwargs):
+        nonlocal calls
+        calls += 1
+        if calls < 3:
+            raise ToolNotDeployedError("boltz2-prediction", "proto-tools-boltz2")
+        return expected
+
+    monkeypatch.setattr("proto_tools.modal.dispatch_to_modal", dispatch)
+    monkeypatch.setattr(
+        "proto_tools.modal.deploy.deploy_app",
+        lambda app, env: deployed.append((app, env)) or True,
+    )
+    monkeypatch.setattr("proto_language.modal._deployment_lock", lambda *_args: nullcontext())
+
+    result = _dispatch_with_deployment("boltz2-prediction", object(), object(), "hackathon")
+
+    assert result is expected
+    assert deployed == [("proto-tools-boltz2", "hackathon")]
+
+
+def test_failed_deploy_never_falls_back_to_local_execution(monkeypatch: pytest.MonkeyPatch) -> None:
+    from proto_tools.modal import ToolNotDeployedError
+
+    calls = 0
+
+    def missing(*_args, **_kwargs):
+        nonlocal calls
+        calls += 1
+        raise ToolNotDeployedError("esmfold-prediction", "proto-tools-esmfold")
+
+    monkeypatch.setattr("proto_tools.modal.dispatch_to_modal", missing)
+    monkeypatch.setattr("proto_tools.modal.deploy.deploy_app", lambda *_args: False)
+    monkeypatch.setattr("proto_language.modal._deployment_lock", lambda *_args: nullcontext())
+
+    with pytest.raises(RuntimeError, match="Failed to deploy Modal app 'proto-tools-esmfold'"):
+        _dispatch_with_deployment("esmfold-prediction", object(), object(), "proto-env")
+
+    assert calls == 2
+
+
+def test_context_installs_and_restores_one_dispatch_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+    from proto_tools.tools import ToolRegistry
+
+    monkeypatch.setattr("proto_tools.modal.app.resolve_environment", lambda value: value or "proto-env")
+    ToolRegistry.clear_dispatch_backend()
+
+    with on_demand_modal_tools():
+        assert ToolRegistry.dispatch_backend_configured()
+
+    assert not ToolRegistry.dispatch_backend_configured()
+
+
+def test_context_does_not_overwrite_an_existing_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+    from proto_tools.tools import ToolRegistry
+
+    def existing(*_args):
+        return None
+
+    ToolRegistry.configure_dispatch_backend(existing)
+    try:
+        with pytest.raises(RuntimeError, match="another dispatch backend"):
+            with on_demand_modal_tools():
+                pass
+        assert ToolRegistry.dispatch_backend_configured()
+    finally:
+        ToolRegistry.clear_dispatch_backend()
+
+
+def test_unrelated_thread_is_not_captured_by_modal_scope(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The process-global registry hook must remain scoped to the initiating context."""
+    from proto_tools.tools import ToolRegistry
+
+    monkeypatch.setattr("proto_tools.modal.app.resolve_environment", lambda value: value or "proto-env")
+    monkeypatch.setattr(
+        "proto_language.modal._dispatch_with_deployment",
+        lambda *_args: pytest.fail("an unrelated thread was routed to Modal"),
+    )
+
+    with on_demand_modal_tools():
+        backend = ToolRegistry._dispatch_backend
+        assert backend is not None
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            result = executor.submit(backend, "any-tool", object(), object()).result()
+
+    assert result is None
+
+
+def test_program_modal_scope_skips_local_tool_pool(monkeypatch: pytest.MonkeyPatch) -> None:
+    from proto_tools.tools import ToolRegistry
+
+    from proto_language.constraint import ConstraintRegistry
+    from proto_language.core import Construct, Program, Segment
+    from proto_language.generator import RandomNucleotideGenerator, RandomNucleotideGeneratorConfig
+    from proto_language.optimizer import RejectionSamplingOptimizer, RejectionSamplingOptimizerConfig
+
+    segment = Segment(sequence="ATGC", sequence_type="dna")
+    generator = RandomNucleotideGenerator(RandomNucleotideGeneratorConfig())
+    generator.assign(segment)
+    constraint = ConstraintRegistry.create(
+        key="gc-content",
+        segments=[segment],
+        config_dict={"min_gc": 0, "max_gc": 100},
+    )
+    optimizer = RejectionSamplingOptimizer(
+        constructs=[Construct([segment])],
+        generators=[generator],
+        constraints=[constraint],
+        config=RejectionSamplingOptimizerConfig(num_samples=1, num_results=1),
+    )
+    program = Program([optimizer], num_results=1)
+
+    class RefusingCompute:
+        def __enter__(self):
+            pytest.fail("device='modal' entered the local ToolPool")
+
+        def __exit__(self, *_args):
+            return None
+
+    program.compute = RefusingCompute()
+    observed: list[bool] = []
+    monkeypatch.setattr("proto_tools.modal.app.resolve_environment", lambda value: value or "proto-env")
+    monkeypatch.setattr(
+        program, "run_stage", lambda _stage: observed.append(ToolRegistry.dispatch_backend_configured())
+    )
+
+    program.run(device="modal")
+
+    assert observed == [True]
+    assert not ToolRegistry.dispatch_backend_configured()

--- a/tests/language_tests/test_modal_planning.py
+++ b/tests/language_tests/test_modal_planning.py
@@ -111,6 +111,21 @@ def test_context_routes_gpu_tools_to_modal(monkeypatch: pytest.MonkeyPatch) -> N
         assert backend("esm2-sample", object(), object()) is expected
 
 
+def test_context_leaves_local_only_gpu_tools_local(monkeypatch: pytest.MonkeyPatch) -> None:
+    from proto_tools.tools import ToolRegistry
+
+    monkeypatch.setattr("proto_tools.modal.app.resolve_environment", lambda value: value or "proto-env")
+    monkeypatch.setattr(
+        "proto_language.modal._dispatch_with_deployment",
+        lambda *_args: pytest.fail("a local-only GPU tool was routed to Modal"),
+    )
+
+    with on_demand_modal_tools():
+        backend = ToolRegistry._dispatch_backend
+        assert backend is not None
+        assert backend("alphafold3-prediction", object(), object()) is None
+
+
 def test_context_does_not_overwrite_an_existing_backend(monkeypatch: pytest.MonkeyPatch) -> None:
     from proto_tools.tools import ToolRegistry
 

--- a/tests/language_tests/test_program.py
+++ b/tests/language_tests/test_program.py
@@ -1298,7 +1298,7 @@ class TestProgramCompute:
         ToolRegistry.configure_dispatch_backend(lambda key, inputs, config: None)
         try:
             program = _create_simple_program(compute=None)
-            assert isinstance(program.compute, nullcontext)
+            assert isinstance(program._resolve_compute(), nullcontext)
             mock_pool_cls.assert_not_called()
         finally:
             ToolRegistry.clear_dispatch_backend()


### PR DESCRIPTION
## What changed

- Add `Program.run(device="modal")` and matching stage-level opt-in.
- Keep the optimization loop and CPU tools local.
- Route only GPU-backed language-layer tool calls through Modal.
- Deploy only the exact missing GPU app on first use, then retry the call.
- Recheck under a cross-process lock to avoid duplicate first deployments.
- Keep unrelated threads and existing dispatch backends isolated.
- Document the first-use billing behavior.

## Why

Language optimization runs should not eagerly deploy the full Modal tool catalog. CPU tools do not need remote GPU infrastructure, while GPU apps should be allocated only when an optimization actually reaches them.

## Impact

- No `proto-language-api` changes.
- No `proto-tools` changes or submodule diff.
- Existing local runs are unchanged.
- `device="modal"` is the explicit cost-bearing opt-in for GPU tool calls; CPU tools remain local and unused GPU tools deploy nothing.
- Missing GPU deployments fail without local fallback if deployment cannot complete.

## Validation

- Full suite before the routing correction: 3,928 passed, 253 skipped, 0 failed.
- Focused routing/program/cycling suite after the correction: 106 passed, 2 existing slow GPU-local tests skipped.
- Focused Modal routing suite: 10 passed.
- Actual default examples: `toy.py`, `toy-multiple-optimizers.py`, and `gradient_protein_hallucination.py` passed with local optimizer execution.
- Mixed full optimization: local random-protein generation plus remote ESMFold scoring passed and exported its PDB/results.
- Complex live runs: two-cycle Protein Hunter with remote Boltz2 + ProteinMPNN, and two-step MCMC with remote ESM2 + ESMFold, passed.
- `ruff check` and `ruff format --check` passed for changed Python files.
- `git diff --check` passed.

## Adversarial review

Reviewed deployment selectivity, CPU/GPU routing, duplicate first-call races, failed-deploy behavior, backend restoration, unrelated-thread capture, environment forwarding, local ToolPool preservation, and deployment reuse. The review found and fixed two routing issues: process-global backend leakage was scoped with a `ContextVar`, and CPU tools were restored to normal local execution instead of being treated as missing Modal deployments.