### PR TITLE
Preserve protein types in Protein Hunter cycles

### DIFF
--- a/examples/scripts/evocas9_rejection_sampling.py
+++ b/examples/scripts/evocas9_rejection_sampling.py
@@ -163,6 +163,7 @@ def structure_filter(
     from proto_tools import (
         AlphaFold3Config,
         AlphaFold3Input,
+        Chain,
         Complex,
         Mmseqs2HomologySearchConfig,
         run_alphafold3,
@@ -236,7 +237,7 @@ def structure_filter(
         proposal_dir = f"{af3_dir}/{af3_name}_{af3_idx}"
         try:
             af3_result = run_alphafold3(
-                AlphaFold3Input(complexes=[Complex(chains=[protein])]),
+                AlphaFold3Input(complexes=[Complex(chains=[Chain(sequence=protein, entity_type="protein")])]),
                 AlphaFold3Config(
                     name=af3_name,
                     output_dir=proposal_dir,

--- a/examples/scripts/protein_hunter.py
+++ b/examples/scripts/protein_hunter.py
@@ -21,7 +21,7 @@ import os
 import sys
 from datetime import datetime
 
-from proto_tools import Complex, predict_structures
+from proto_tools import Chain, Complex, predict_structures
 
 from proto_language.core import Construct, Program, Segment, Sequence
 from proto_language.generator import (
@@ -151,7 +151,9 @@ def run_protein_hunter(
         # Define conditioning function.
         def structure_conditioning_fn(sequences: list[Sequence]) -> list:
             """Predict 3D structures and store PDBs in metadata for retrieval later."""
-            complexes = [Complex(chains=[seq.sequence]) for seq in sequences]
+            complexes = [
+                Complex(chains=[Chain(sequence=seq.sequence, entity_type=seq.sequence_type)]) for seq in sequences
+            ]
 
             structures = predict_structures(complexes, structure_tool, {}).structures
 

--- a/proto_language/optimizer/cycling_optimizer.py
+++ b/proto_language/optimizer/cycling_optimizer.py
@@ -9,7 +9,7 @@ proposals passing the filter constraints. Repeating drives feedback loops such a
 segment.
 
 Examples:
-    >>> from proto_tools import Complex, predict_structures
+    >>> from proto_tools import Chain, Complex, predict_structures
     >>> from proto_language.core import Construct, Program, Segment, Sequence
     >>> from proto_language.generator import ProteinMPNNGenerator, ProteinMPNNGeneratorConfig
     >>> from proto_language.optimizer import CyclingOptimizer, CyclingOptimizerConfig
@@ -17,7 +17,9 @@ Examples:
     >>> gen = ProteinMPNNGenerator(ProteinMPNNGeneratorConfig(temperature=0.1, excluded_amino_acids=["C"]))
     >>> gen.assign(protein)
     >>> def structure_conditioning_fn(sequences: list[Sequence]) -> list:
-    ...     complexes = [Complex(chains=[seq.sequence]) for seq in sequences]
+    ...     complexes = [
+    ...         Complex(chains=[Chain(sequence=seq.sequence, entity_type=seq.sequence_type)]) for seq in sequences
+    ...     ]
     ...     return predict_structures(complexes, "boltz2", {}).structures  # condition each cycle on folds
     >>> optimizer = CyclingOptimizer(
     ...     target_segment=protein,
@@ -88,7 +90,7 @@ def _create_protein_hunter_conditioning_fn(config: "CyclingOptimizerConfig") -> 
     Args:
         config (CyclingOptimizerConfig): Constraint configuration controlling evaluation parameters.
     """
-    from proto_tools import Complex, predict_structures
+    from proto_tools import Chain, Complex, predict_structures
 
     structure_tool = config.protein_hunter.structure_tool if config.protein_hunter else "boltz2"
 
@@ -106,7 +108,7 @@ def _create_protein_hunter_conditioning_fn(config: "CyclingOptimizerConfig") -> 
         rng = state["rng"]
         if rng is not None:
             tool_config["seed"] = rng.randint(0, 2**31 - 1)
-        complexes = [Complex(chains=[seq.sequence]) for seq in sequences]
+        complexes = [Complex(chains=[Chain(sequence=seq.sequence, entity_type=seq.sequence_type)]) for seq in sequences]
         structures = predict_structures(complexes, structure_tool, tool_config).structures
         for seq, structure in zip(sequences, structures, strict=True):
             seq.structure = structure

--- a/tests/language_tests/optimizer_tests/test_cycling_optimizer.py
+++ b/tests/language_tests/optimizer_tests/test_cycling_optimizer.py
@@ -1065,6 +1065,32 @@ class TestCyclingOptimizerPipelineResolution:
         )
         assert optimizer.pipeline == "protein-hunter"
 
+    def test_protein_hunter_preserves_ambiguous_protein_type(self, monkeypatch):
+        """Protein-only sequences must not be reinterpreted as DNA before folding."""
+        from proto_language.optimizer import cycling_optimizer as co
+
+        captured: list[Any] = []
+
+        class _FakeOutput:
+            def __init__(self, n: int):
+                self.structures = [make_mock_structure() for _ in range(n)]
+
+        def _fake_predict_structures(complexes, _toolkit, _tool_config):
+            captured.extend(complexes)
+            return _FakeOutput(len(complexes))
+
+        import proto_tools
+
+        monkeypatch.setattr(proto_tools, "predict_structures", _fake_predict_structures)
+
+        cfg = CyclingOptimizerConfig(num_steps=1, num_results=1, pipeline="protein-hunter")
+        fn = co._create_protein_hunter_conditioning_fn(cfg)
+        fn([Sequence(sequence="A" * 10, sequence_type="protein")])
+
+        chain = captured[0].chains[0]
+        assert chain.entity_type == "protein"
+        assert chain.entity_type_inferred is False
+
     def test_protein_hunter_passes_cycle_seed_for_stochastic_tool(self, monkeypatch):
         """conditioning_fn must provide seeded runs to a `stochastic=True` @tool.
 


### PR DESCRIPTION
## Summary

- preserve each `Sequence.sequence_type` when Protein Hunter builds proto-tools complexes
- apply the same typed-chain construction in the standalone Protein Hunter example and public optimizer example
- add a regression test for an all-alanine protein, whose alphabet is ambiguous with DNA

## Root cause

Protein Hunter previously reduced a typed proto-language `Sequence` to a raw string:

```python
Complex(chains=[seq.sequence])
```

Proto-tools intentionally infers an untyped `A`-only string as DNA because DNA is checked before protein. If ProteinMPNN generated an all-alanine sequence, the next cycle therefore asked the structure predictor to fold DNA. Boltz returned `DA` residues without a protein `N`/`CA`/`C` backbone, and ProteinMPNN failed while parsing that structure.

The pipeline now constructs an explicit `Chain` carrying the source sequence type:

```python
Complex(chains=[Chain(sequence=seq.sequence, entity_type=seq.sequence_type)])
```

This retains proto-language's already-known biological type instead of asking proto-tools to infer it again.

## User impact

Protein Hunter cycles no longer fail when a valid protein proposal happens to contain only characters shared with the DNA alphabet, including the observed all-alanine case. Ordinary non-ambiguous protein sequences behave unchanged.

## Scope

This is intentionally limited to proto-language's Protein Hunter construction paths. It does not alter proto-tools inference rules, Modal deployment behavior, or the separate generic issue where a Modal `success=False` envelope can be reported as an output-schema error.

## Validation

- Regression test failed before the fix with `AssertionError: assert 'dna' == 'protein'` and passes after it.
- `pytest tests/language_tests/optimizer_tests/test_cycling_optimizer.py --cpu-only -q`: 30 passed, 2 expected GPU skips.
- `pytest --all --ext --cpu-only --random-order -q`: 3,940 passed, 232 expected skips, 0 failures/errors.
- `ruff check .`
- `ruff format --check .`
- `mypy proto_language/`
- `python .github/scripts/validate_exports.py --verbose`
- Live Modal A/B verification: an untyped 40-`A` chain produced 40 `DA` residues and reproduced the ProteinMPNN parser failure; the explicitly typed protein chain produced 40 `ALA` residues with complete backbones and ProteinMPNN returned a valid design set.
