### PR TITLE
Validate gradient provider output contracts

### DIFF
--- a/notes/error-handling.md
+++ b/notes/error-handling.md
@@ -57,6 +57,8 @@ Config construction errors raise.
 Raise for impossible states and programmer bugs. Examples:
 
 - Returned constraint result count does not match evaluated proposals.
+- A gradient provider returns the wrong proposal count, a gradient whose shape differs
+  from the target logits, or a non-finite gradient, loss, weight, or aggregate energy.
 - A scoring constraint returns booleans or a filter returns invalid result shapes.
 - A `ConstraintOutput` has an out-of-range score, wrong type, or wrong structures/logits arity.
 - A proposal that passed all filters has `NaN` energy.

--- a/proto_language/core/constraint.py
+++ b/proto_language/core/constraint.py
@@ -41,6 +41,7 @@ Examples:
 """
 
 import logging
+import math
 from collections.abc import Callable, Iterable
 from typing import Any, Protocol
 
@@ -737,6 +738,8 @@ class Constraint:
         for idx, (result, inputs_tuple) in enumerate(zip(results, all_input_tuples, strict=True)):
             if not isinstance(result, GradientConstraintOutput):
                 raise TypeError(f"'{self.label}': expected GradientConstraintOutput, got {type(result).__name__}")
+            if not math.isfinite(result.loss):
+                raise ValueError(f"'{self.label}' proposal {idx}: non-finite loss {result.loss}.")
             if len(result.gradient) != n_inputs:
                 raise ValueError(f"'{self.label}': {len(result.gradient)} gradients, expected {n_inputs}")
             for seg_idx, (grad, seq) in enumerate(zip(result.gradient, inputs_tuple, strict=True)):

--- a/proto_language/optimizer/constraint_compiler/__init__.py
+++ b/proto_language/optimizer/constraint_compiler/__init__.py
@@ -3,6 +3,7 @@
 from proto_language.optimizer.constraint_compiler.base import (
     GradientProvider,
     GradientProviderOutput,
+    validate_gradient_provider_output,
 )
 from proto_language.optimizer.constraint_compiler.compiler import (
     DirectGradientProvider,
@@ -26,4 +27,5 @@ __all__ = [
     "constraint_supports_compiled_gradient",
     "evaluate_scoring_constraints",
     "gradient_support_for_constraint_spec",
+    "validate_gradient_provider_output",
 ]

--- a/proto_language/optimizer/constraint_compiler/base.py
+++ b/proto_language/optimizer/constraint_compiler/base.py
@@ -9,9 +9,11 @@ function-local imports that would otherwise be needed.
 
 from __future__ import annotations
 
+import math
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
+from numbers import Real
 from typing import Any
 
 import numpy as np
@@ -85,6 +87,63 @@ class GradientProviderOutput:
     gradients: list[np.ndarray]
     losses: list[float]
     weight: float = 1.0
+
+
+def validate_gradient_provider_output(
+    output: GradientProviderOutput,
+    *,
+    expected_logits: list[np.ndarray],
+    step: int,
+) -> None:
+    """Validate one provider result against the optimizer target proposals."""
+    expected_count = len(expected_logits)
+    if len(output.gradients) != expected_count:
+        raise ValueError(
+            f"Gradient provider '{output.label}' returned {len(output.gradients)} gradients at step {step}, "
+            f"expected {expected_count}."
+        )
+    if len(output.losses) != expected_count:
+        raise ValueError(
+            f"Gradient provider '{output.label}' returned {len(output.losses)} losses at step {step}, "
+            f"expected {expected_count}."
+        )
+    weight: object = output.weight
+    if isinstance(weight, bool) or not isinstance(weight, Real):
+        raise TypeError(f"Gradient provider '{output.label}' returned non-numeric weight {weight!r} at step {step}.")
+    if not math.isfinite(float(weight)):
+        raise ValueError(
+            f"Gradient provider '{output.label}' returned non-finite weight {output.weight} at step {step}."
+        )
+
+    for proposal_idx, (gradient, loss, logits) in enumerate(
+        zip(output.gradients, output.losses, expected_logits, strict=True)
+    ):
+        if not isinstance(gradient, np.ndarray):
+            raise TypeError(
+                f"Gradient provider '{output.label}' returned {type(gradient).__name__} gradient at step {step} "
+                f"(proposal {proposal_idx}), expected ndarray."
+            )
+        if gradient.shape != logits.shape:
+            raise ValueError(
+                f"Gradient provider '{output.label}' returned gradient shape {gradient.shape} at step {step} "
+                f"(proposal {proposal_idx}), expected logits shape {logits.shape}."
+            )
+        if not np.isfinite(gradient).all():
+            raise ValueError(
+                f"Gradient provider '{output.label}' returned non-finite gradient at step {step} "
+                f"(proposal {proposal_idx})."
+            )
+        loss_value: object = loss
+        if isinstance(loss_value, bool) or not isinstance(loss_value, Real):
+            raise TypeError(
+                f"Gradient provider '{output.label}' returned non-numeric loss {loss_value!r} at step {step} "
+                f"(proposal {proposal_idx})."
+            )
+        if not math.isfinite(float(loss_value)):
+            raise ValueError(
+                f"Gradient provider '{output.label}' returned non-finite loss {loss} at step {step} "
+                f"(proposal {proposal_idx})."
+            )
 
 
 class GradientProvider(ABC):

--- a/proto_language/optimizer/gradient_optimizer.py
+++ b/proto_language/optimizer/gradient_optimizer.py
@@ -50,6 +50,7 @@ from proto_language.optimizer.constraint_compiler import (
     GradientProviderOutput,
     compile_gradient_providers,
     constraint_supports_compiled_gradient,
+    validate_gradient_provider_output,
 )
 from proto_language.optimizer.optimizer_registry import optimizer
 from proto_language.utils import softmax
@@ -739,10 +740,13 @@ class GradientOptimizer(Optimizer):
                 )
                 for provider in self._gradient_providers
             ]
+            expected_logits: list[np.ndarray] = []
+            for proposal_idx, proposal in enumerate(target.proposal_sequences):
+                if proposal.logits is None:
+                    raise RuntimeError(f"Gradient target proposal {proposal_idx} has no logits at step {step}.")
+                expected_logits.append(proposal.logits)
             for output in provider_outputs:
-                for k, grad in enumerate(output.gradients):
-                    if not np.isfinite(grad).all():
-                        raise ValueError(f"Non-finite gradient from '{output.label}' at step {step} (proposal {k}).")
+                validate_gradient_provider_output(output, expected_logits=expected_logits, step=step)
 
             # Pair each saved energy with the logits that produced it (provider losses are pre-update).
             if self.config.save_best:
@@ -756,6 +760,9 @@ class GradientOptimizer(Optimizer):
 
             # Report the same weighted objective that gradient descent is actually minimizing.
             self.energy_scores = [sum(output.losses[k] for output in provider_outputs) for k in range(self.num_results)]
+            for proposal_idx, energy in enumerate(self.energy_scores):
+                if not np.isfinite(energy):
+                    raise ValueError(f"Non-finite aggregate gradient energy at step {step} (proposal {proposal_idx}).")
             self._proposal_outcomes = ["accepted"] * self.num_proposals
             self._proposal_energy_scores = list(self.energy_scores)
 

--- a/tests/language_tests/constraint_tests/test_base_constraint.py
+++ b/tests/language_tests/constraint_tests/test_base_constraint.py
@@ -730,6 +730,23 @@ class TestConstraintGradientSupport:
         assert results[0].gradient[0].shape == (8, 4)
         np.testing.assert_array_almost_equal(results[0].gradient[0], -logits)
 
+    @pytest.mark.parametrize("loss", [float("nan"), float("inf"), float("-inf")])
+    def test_compute_gradient_rejects_non_finite_loss(self, loss: float) -> None:
+        segment = _make_segment_with_proposals(["ACTGACTG"])
+        segment.proposal_sequences[0].logits = np.zeros((8, 4))
+
+        def backward(
+            input_sequences: list[tuple[Sequence, ...]], *, config: BaseModel, **kwargs: Any
+        ) -> list[GradientConstraintOutput]:
+            return [
+                GradientConstraintOutput(gradient=(np.zeros_like(seq.logits),), loss=loss) for (seq,) in input_sequences
+            ]
+
+        constraint = Constraint(inputs=[segment], backward=backward, backward_config=MockConfig(), label="unstable")
+
+        with pytest.raises(ValueError, match=r"unstable.*non-finite loss"):
+            constraint.compute_gradient()
+
     def test_gradient_positions_mask_rows(self) -> None:
         """gradient_positions keeps selected rows and zeroes the rest."""
         segment = _make_segment_with_proposals(["ACTGACTG"])

--- a/tests/language_tests/optimizer_tests/test_gradient_optimizer.py
+++ b/tests/language_tests/optimizer_tests/test_gradient_optimizer.py
@@ -27,6 +27,7 @@ from proto_language.optimizer import (
     MCMCOptimizer,
     MCMCOptimizerConfig,
 )
+from proto_language.optimizer.constraint_compiler import GradientProviderOutput
 from proto_language.utils.scheduling import hinge_schedule
 from proto_language.utils.sequence_matrices import SequenceLogitBiasConfig
 
@@ -555,6 +556,39 @@ class TestValidation:
 
         opt = _make_optimizer(Segment(sequence="AA", sequence_type="protein"), nan_bwd, label="naughty", num_steps=1)
         with pytest.raises(ValueError, match="naughty"):
+            opt.run()
+
+    def test_compiled_provider_gradient_must_match_target_logits(self) -> None:
+        opt = _make_optimizer(Segment(sequence="AAAAA", sequence_type="protein"), _backward, num_steps=1)
+        output = GradientProviderOutput(
+            label="bad-shape",
+            gradients=[np.zeros((1, 20))],
+            losses=[0.0],
+        )
+        opt._gradient_providers[0].compute = lambda **kwargs: output  # type: ignore[method-assign]
+
+        with pytest.raises(ValueError, match=r"bad-shape.*gradient shape \(1, 20\).*logits shape \(5, 20\)"):
+            opt.run()
+
+    @pytest.mark.parametrize("loss", [float("nan"), float("inf"), float("-inf")])
+    def test_provider_loss_must_be_finite(self, loss: float) -> None:
+        opt = _make_optimizer(Segment(sequence="AA", sequence_type="protein"), _backward, num_steps=1)
+        output = GradientProviderOutput(
+            label="unstable-provider",
+            gradients=[np.zeros((2, 20))],
+            losses=[loss],
+        )
+        opt._gradient_providers[0].compute = lambda **kwargs: output  # type: ignore[method-assign]
+
+        with pytest.raises(ValueError, match=r"unstable-provider.*non-finite loss"):
+            opt.run()
+
+    def test_provider_result_counts_must_match_proposals(self) -> None:
+        opt = _make_optimizer(Segment(sequence="AA", sequence_type="protein"), _backward, num_steps=1)
+        output = GradientProviderOutput(label="missing-result", gradients=[], losses=[])
+        opt._gradient_providers[0].compute = lambda **kwargs: output  # type: ignore[method-assign]
+
+        with pytest.raises(ValueError, match=r"missing-result.*0 gradients.*expected 1"):
             opt.run()
 
 


### PR DESCRIPTION
## Summary

- Validate every gradient provider result before it reaches aggregation.
- Reject mismatched gradient counts, non-array gradients, incorrect shapes, and non-finite gradient values, losses, or weights.
- Apply the same finite-value contract to direct constraint losses and the optimizer's aggregate energy.
- Document hard-failure behavior and add focused regression coverage.

## Architectural issue

The compiler boundary previously trusted provider-owned arrays and scalar metadata. A malformed provider result could therefore propagate into optimization and fail later with an opaque NumPy error, or silently poison the state with NaN/Inf values. This change makes the provider boundary the single enforcement point for the gradient output contract.

## Validation

- `pytest --cpu-only -q --override-ini="log_cli=false"`: 3,968 passed, 254 expected skips
- `ruff check proto_language tests`: passed
- `ruff format --check`: passed
- `mypy proto_language/`: passed
- `python .github/scripts/validate_exports.py --verbose`: passed

## Stack

Stack 1 of 6. Base: `main`. Next: `fix/direct-gradient-routing`.