### PR TITLE
Honor direct gradient routing

### DIFF
--- a/proto_language/optimizer/constraint_compiler/compiler.py
+++ b/proto_language/optimizer/constraint_compiler/compiler.py
@@ -21,6 +21,7 @@ from a public backward function or from a backend-specific grouped model call.
 
 from typing import Any
 
+import numpy as np
 from pydantic import BaseModel
 
 from proto_language.constraint.constraint_registry import ConstraintSpec
@@ -45,21 +46,23 @@ class DirectGradientProvider(GradientProvider):
     """Provider for one constraint that already exposes a backward callable.
 
     Direct providers are the non-compiled path. They call
-    ``Constraint.compute_gradient`` and then select the gradient entry for the
-    optimizer target segment. This is the reference behavior that compiled
-    backend providers must emulate.
+    ``Constraint.compute_gradient`` and then sum the gradient entries for every
+    input position occupied by the optimizer target segment. This is the
+    reference behavior that compiled backend providers must emulate.
     """
 
-    def __init__(self, constraint: Constraint, target_index: int):
+    def __init__(self, constraint: Constraint, target_indices: tuple[int, ...]):
         """Create a provider for ``constraint``.
 
         Args:
             constraint (Constraint): Differentiable public constraint.
-            target_index (int): Position of the optimizer target segment inside the
-                constraint's input list.
+            target_indices (tuple[int, ...]): Positions of the optimizer target
+                segment inside the constraint's input list.
         """
+        if not target_indices:
+            raise ValueError(f"Constraint '{constraint.label}' inputs do not include the optimizer target segment.")
         self.constraint = constraint
-        self.target_index = target_index
+        self.target_indices = target_indices
         self.label = constraint.label
 
     def compute(
@@ -87,7 +90,13 @@ class DirectGradientProvider(GradientProvider):
         weight = effective_weight(self.constraint, step)
         return GradientProviderOutput(
             label=self.label,
-            gradients=[result.gradient[self.target_index] for result in results],
+            gradients=[
+                sum(
+                    (result.gradient[index] for index in self.target_indices),
+                    start=np.zeros_like(result.gradient[self.target_indices[0]]),
+                )
+                for result in results
+            ],
             losses=[weight * result.loss for result in results],
             weight=weight,
         )
@@ -128,6 +137,13 @@ def compile_gradient_providers(constraints: list[Constraint], target_segment: Se
     malinois_provider_by_key: dict[tuple[Any, ...], malinois.MalinoisGradientProvider] = {}
 
     for constraint in constraints:
+        if constraint.supports_gradient:
+            target_indices = tuple(
+                index for index, segment in enumerate(constraint.inputs) if segment is target_segment
+            )
+            providers.append(DirectGradientProvider(constraint, target_indices))
+            continue
+
         malinois_objective_key = malinois.objective_key_for_constraint(constraint)
         if malinois_objective_key is not None:
             malinois_config = malinois.config_for_constraint(constraint, strict=True)
@@ -148,10 +164,6 @@ def compile_gradient_providers(constraints: list[Constraint], target_segment: Se
                 malinois_provider,
                 CompiledConstraint(constraint=constraint, objective_key=malinois_objective_key),
             )
-            continue
-
-        if constraint.supports_gradient:
-            providers.append(DirectGradientProvider(constraint, constraint.inputs.index(target_segment)))
             continue
 
         esmfold_objective_key = esmfold.objective_key_for_constraint(constraint)
@@ -334,6 +346,14 @@ def constraint_supports_compiled_gradient(
             the current compiler. Otherwise returns ``(False, reason)`` with a
             message suitable for optimizer errors.
     """
+    if constraint.supports_gradient:
+        if target_segment is not None and target_segment not in constraint.inputs:
+            return False, (
+                f"Constraint '{constraint.label}' inputs do not include the optimizer target_segment; "
+                "GradientOptimizer can only differentiate constraints whose inputs contain the target."
+            )
+        return True, None
+
     malinois_objective_key = malinois.objective_key_for_constraint(constraint)
     if malinois_objective_key is not None:
         malinois_config = malinois.config_for_constraint(constraint)
@@ -345,14 +365,6 @@ def constraint_supports_compiled_gradient(
             malinois.validate_gradient_constraint(constraint, target_segment, malinois_config)
         except (TypeError, ValueError) as exc:
             return False, str(exc)
-        return True, None
-
-    if constraint.supports_gradient:
-        if target_segment is not None and target_segment not in constraint.inputs:
-            return False, (
-                f"Constraint '{constraint.label}' inputs do not include the optimizer target_segment; "
-                "GradientOptimizer can only differentiate constraints whose inputs contain the target."
-            )
         return True, None
 
     esmfold_objective_key = esmfold.objective_key_for_constraint(constraint)

--- a/tests/language_tests/optimizer_tests/test_constraint_compiler.py
+++ b/tests/language_tests/optimizer_tests/test_constraint_compiler.py
@@ -1,9 +1,22 @@
-"""Tests for compiler-backed gradient support metadata."""
+"""Tests for compiler-backed gradient support metadata and direct routing."""
 
+import numpy as np
 import pytest
+from pydantic import BaseModel
 
-from proto_language.constraint import ConstraintRegistry
-from proto_language.optimizer.constraint_compiler import gradient_support_for_constraint_spec
+from proto_language import GradientConstraintOutput
+from proto_language.constraint import ConstraintRegistry, MalinoisActivityConfig, malinois_activity_constraint
+from proto_language.core import Constraint, Segment, Sequence
+from proto_language.optimizer.constraint_compiler import (
+    DirectGradientProvider,
+    compile_gradient_providers,
+    constraint_supports_compiled_gradient,
+    gradient_support_for_constraint_spec,
+)
+
+
+class _Config(BaseModel):
+    """Empty test config."""
 
 
 @pytest.mark.parametrize(
@@ -33,3 +46,59 @@ def test_af2_binder_rule_targets_binder_input() -> None:
         "alphafold2_binder_config.binder_input_index",
         "alphafold2_binder_config.target_input_indices",
     ]
+
+
+def test_explicit_backward_takes_precedence_over_malinois_compilation() -> None:
+    segment = Segment(sequence="A" * 200, sequence_type="dna")
+
+    def backward(
+        input_sequences: list[tuple[Sequence, ...]], *, config: BaseModel, **kwargs: object
+    ) -> list[GradientConstraintOutput]:
+        return [
+            GradientConstraintOutput(gradient=(np.zeros_like(sequence.logits),), loss=0.0)
+            for (sequence,) in input_sequences
+        ]
+
+    config = MalinoisActivityConfig(device="cpu")
+    constraint = Constraint(
+        inputs=[segment],
+        function=malinois_activity_constraint,
+        function_config=config,
+        backward=backward,
+        backward_config=config,
+    )
+
+    providers = compile_gradient_providers([constraint], segment)
+
+    assert len(providers) == 1
+    assert isinstance(providers[0], DirectGradientProvider)
+    assert constraint_supports_compiled_gradient(constraint, segment) == (True, None)
+
+
+def test_direct_provider_sums_all_aliased_target_gradients() -> None:
+    segment = Segment(sequence="AA", sequence_type="protein")
+    segment.proposal_sequences[0].logits = np.zeros((2, 20))
+
+    def backward(
+        input_sequences: list[tuple[Sequence, ...]], *, config: BaseModel, **kwargs: object
+    ) -> list[GradientConstraintOutput]:
+        return [
+            GradientConstraintOutput(
+                gradient=(np.ones_like(first.logits), np.full_like(second.logits, 2.0)),
+                loss=1.0,
+            )
+            for first, second in input_sequences
+        ]
+
+    constraint = Constraint(inputs=[segment, segment], backward=backward, backward_config=_Config())
+    (provider,) = compile_gradient_providers([constraint], segment)
+
+    output = provider.compute(
+        temperature=1.0,
+        soft=1.0,
+        hard=0.0,
+        step=1,
+        effective_weight=lambda constraint, step: 1.0,
+    )
+
+    np.testing.assert_array_equal(output.gradients[0], np.full((2, 20), 3.0))


### PR DESCRIPTION
## Summary

- Select a constraint's direct gradient implementation before considering compiler adapters.
- Keep compiler-backed gradients as the fallback for constraints without a direct path.
- Accumulate contributions when the optimized segment appears multiple times in a direct constraint's inputs.
- Add coverage for dual-capability constraints and aliased inputs.

## Architectural issue

A constraint with both a direct gradient function and a matching compiler adapter could be claimed by the adapter first. That made routing depend on registry order instead of the constraint's explicit implementation contract. Repeated references to the same target segment also lost chain-rule contributions. This change makes direct routing deterministic and alias-safe.

## Validation

- `pytest --cpu-only -q --override-ini="log_cli=false"`: 3,968 passed, 254 expected skips
- `ruff check proto_language tests`: passed
- `ruff format --check`: passed
- `mypy proto_language/`: passed
- `python .github/scripts/validate_exports.py --verbose`: passed

## Stack

Stack 2 of 6. Base: `fix/gradient-provider-output-contract`. Next: `refactor/constraint-capability-resolution`.