### PR TITLE
Preserve observability for compiled scoring

### DIFF
--- a/notes/batching.md
+++ b/notes/batching.md
@@ -69,6 +69,15 @@ backend seed cursors therefore advance within one run without mutating public
 constraint configs, and reset reproducibly on the next run. In an unseeded
 program, the first constraint's configured seed remains the group's seed.
 
+Scoring plans return both the aggregate component vectors consumed by energy
+aggregation and one weighted contribution vector per public constraint. A
+backend-returned grouped loss remains the optimization source of truth, while
+progress logs retain term-level visibility even when several constraints share
+one call. Constraint metadata records both `configured_weight` and
+`effective_weight`; the legacy `weight` and `weighted_score` fields use the
+effective runtime value so scheduled gradient objectives are reported with the
+same weight the optimizer applied.
+
 ## Tool-Level Patterns
 
 Treat these as patterns, not a registry. The source of truth is the selected generator, constraint config, and proto-tools runner.

--- a/proto_language/core/constraint.py
+++ b/proto_language/core/constraint.py
@@ -567,12 +567,19 @@ class Constraint:
                         original.logits = lg
 
     def _write_constraint_metadata(
-        self, sequence_idx: int, score: float, metadata: dict[str, Any], metadata_recipient_position: int | None = None
+        self,
+        sequence_idx: int,
+        score: float,
+        metadata: dict[str, Any],
+        metadata_recipient_position: int | None = None,
+        effective_weight: float | None = None,
     ) -> None:
         """Write ``_constraints_metadata[self.label]`` on each unique input proposal.
 
         ``metadata_recipient_position`` restricts custom metadata to one input.
         When unset, custom metadata is copied to all inputs for discoverability.
+        ``effective_weight`` records a scheduled runtime weight while preserving
+        the configured constraint weight separately.
         """
         originals_by_id: dict[int, Sequence] = {}
         metadata_by_original: dict[int, dict[str, Any]] = {}
@@ -588,10 +595,13 @@ class Constraint:
 
         for original_id, original in originals_by_id.items():
             seg_idx = position_by_original[original_id]
+            runtime_weight = self._weight if effective_weight is None else effective_weight
             constraint_data: dict[str, Any] = {
                 "score": make_json_safe(score),
-                "weight": self._weight,
-                "weighted_score": make_json_safe(score * self._weight),
+                "weight": runtime_weight,
+                "configured_weight": self._weight,
+                "effective_weight": runtime_weight,
+                "weighted_score": make_json_safe(score * runtime_weight),
                 "data": metadata_by_original[original_id],
             }
             if len(self._inputs) > 1:
@@ -684,7 +694,12 @@ class Constraint:
                     f"(per input_labels), but {num_inputs} segment(s) were provided."
                 )
 
-    def compute_gradient(self, **kwargs: Any) -> list[GradientConstraintOutput]:
+    def compute_gradient(
+        self,
+        *,
+        effective_weight: float | None = None,
+        **kwargs: Any,
+    ) -> list[GradientConstraintOutput]:
         """Compute gradients for all proposals as a batch, parallel with ``evaluate()``.
 
         Builds a batched input list from all proposals and passes it to the backward
@@ -694,6 +709,8 @@ class Constraint:
 
         Args:
             **kwargs (Any): Forwarded to the backward callable (e.g. ``temperature``, ``soft``, ``hard``).
+            effective_weight (float | None): Runtime scheduled weight to record
+                in metadata. The backward callable does not receive this value.
 
         Returns:
             list[GradientConstraintOutput]: One result per proposal. Raw gradient, loss, and
@@ -757,7 +774,12 @@ class Constraint:
                     if struct is not None:
                         seq.structure = struct
 
-            self._write_constraint_metadata(idx, masked_result.loss, masked_result.metrics)
+            self._write_constraint_metadata(
+                idx,
+                masked_result.loss,
+                masked_result.metrics,
+                effective_weight=effective_weight,
+            )
             masked_results.append(masked_result)
 
         return masked_results

--- a/proto_language/core/optimizer.py
+++ b/proto_language/core/optimizer.py
@@ -307,9 +307,12 @@ class Optimizer(ABC):
                 logger.debug(f"Constraint {idx + 1}: {constraint.label}")
             if self._scoring_plan is None:
                 self._scoring_plan = compile_scoring_plan(scorers, seed=self.seed)
-            all_scores = self._scoring_plan.evaluate(mask=passed, verbose=self.verbose)
+            scoring_evaluation = self._scoring_plan.evaluate(mask=passed, verbose=self.verbose)
+            all_scores = scoring_evaluation.aggregate_scores
+            self._last_constraint_scores = self._label_constraint_scores(scoring_evaluation.constraint_scores)
         else:
             all_scores = []
+            constraint_scores: dict[Constraint, list[float]] = {}
             for idx, constraint in enumerate(scorers):
                 logger.debug(f"Constraint {idx + 1}: {constraint.label}")
                 scores: list[float] = []
@@ -318,14 +321,8 @@ class Optimizer(ABC):
                         raise TypeError(f"Scoring constraint '{constraint.label}' returned boolean score {score!r}.")
                     scores.append(float(score))
                 all_scores.append(scores)
-
-        # Compiler may group scorers into fewer scoring units (e.g. AF2 binder terms),
-        # so per-constraint mapping only works in the 1:1 case.
-        self._last_constraint_scores = (
-            {scorer.label: scores for scorer, scores in zip(scorers, all_scores, strict=True)}
-            if len(all_scores) == len(scorers)
-            else {}
-        )
+                constraint_scores[constraint] = scores
+            self._last_constraint_scores = self._label_constraint_scores(constraint_scores)
 
         # Warn if no scoring constraints exist (all are filters)
         if not all_scores:
@@ -388,6 +385,29 @@ class Optimizer(ABC):
         ]
         rej_str = f" (rejected: {', '.join(rejections)})" if rejections else ""
         return f"{total_passed}/{total_evaluated}{rej_str}"
+
+    def _label_constraint_scores(self, scores: dict[Constraint, list[float]]) -> dict[str, list[float]]:
+        """Assign unambiguous progress labels to per-constraint score vectors."""
+        label_counts: dict[str, int] = {}
+        for constraint in scores:
+            label_counts[constraint.label] = label_counts.get(constraint.label, 0) + 1
+
+        labeled: dict[str, list[float]] = {}
+        for constraint, values in scores.items():
+            label = constraint.label
+            if label_counts[label] > 1:
+                inputs = ",".join(
+                    f"{segment.construct_label or 'construct'}.{segment.label or 'segment'}"
+                    for segment in constraint.inputs
+                )
+                label = f"{label}[{inputs}]"
+            suffix = 1
+            base_label = label
+            while label in labeled:
+                label = f"{base_label}_{suffix}"
+                suffix += 1
+            labeled[label] = values
+        return labeled
 
     def _format_scoring_lines(self) -> list[str]:
         """Per-constraint mean weighted contribution to energy + % share, one line each."""

--- a/proto_language/optimizer/constraint_compiler/__init__.py
+++ b/proto_language/optimizer/constraint_compiler/__init__.py
@@ -3,6 +3,7 @@
 from proto_language.optimizer.constraint_compiler.base import (
     GradientProvider,
     GradientProviderOutput,
+    ScoringEvaluation,
     validate_gradient_provider_output,
 )
 from proto_language.optimizer.constraint_compiler.compiler import (
@@ -28,6 +29,7 @@ __all__ = [
     "GradientProviderOutput",
     "GradientRule",
     "GradientSupport",
+    "ScoringEvaluation",
     "ScoringPlan",
     "compile_gradient_providers",
     "compile_scoring_plan",

--- a/proto_language/optimizer/constraint_compiler/alphafold2_binder_provider.py
+++ b/proto_language/optimizer/constraint_compiler/alphafold2_binder_provider.py
@@ -56,6 +56,7 @@ from proto_language.optimizer.constraint_compiler.base import (
     EffectiveWeight,
     GradientProvider,
     GradientProviderOutput,
+    ScoringEvaluation,
     _sum_weights_by_objective_key,
     config_group_identity,
     raise_for_failed_tool_output,
@@ -180,8 +181,10 @@ class AF2BinderGradientProvider(GradientProvider):
             RuntimeError: If a binder proposal has no logits or the AF2 binder tool
                 does not return a gradient for a gradient request.
         """
+        effective_weights = [effective_weight(compiled.constraint, step) for compiled in self.constraints]
         loss_weights = _sum_weights_by_objective_key(
-            (compiled.objective_key, effective_weight(compiled.constraint, step)) for compiled in self.constraints
+            (compiled.objective_key, weight)
+            for compiled, weight in zip(self.constraints, effective_weights, strict=True)
         )
         num_proposals = self.inputs[0].num_proposals
         binder_slot = self.config.binder_input_index
@@ -247,7 +250,7 @@ class AF2BinderGradientProvider(GradientProvider):
             losses.append(output.loss)
             structures = af2_binder_structures(output.structure, self.config, len(self.inputs))
 
-            for compiled in self.constraints:
+            for compiled, weight in zip(self.constraints, effective_weights, strict=True):
                 score = _term_score(output.metrics, compiled.objective_key, output.loss)
                 metadata = af2_binder_constraint_output_metadata(
                     output.metrics,
@@ -256,7 +259,12 @@ class AF2BinderGradientProvider(GradientProvider):
                     loss_key=compiled.objective_key,
                     group_loss=output.loss,
                 )
-                compiled.constraint._write_constraint_metadata(proposal_idx, score, metadata)
+                compiled.constraint._write_constraint_metadata(
+                    proposal_idx,
+                    score,
+                    metadata,
+                    effective_weight=weight,
+                )
 
             processed_ids: set[int] = set()
             for seg_idx, segment in enumerate(self.inputs):
@@ -494,7 +502,7 @@ def evaluate_scoring_group(
     compiled_constraints: list[CompiledConstraint],
     mask: list[bool],
     execution_config: StructureBasedConstraintConfig,
-) -> list[float]:
+) -> ScoringEvaluation:
     """Evaluate a compatible group of AF2 binder scoring constraints.
 
     The AF2 binder tool returns the weighted sum of the requested loss terms for each
@@ -511,11 +519,8 @@ def evaluate_scoring_group(
             config shared by the compiled group.
 
     Returns:
-        list[float]: Proposal-aligned weighted grouped scores.
-
-    Raises:
-        ValueError: If the group's first constraint no longer has parseable
-            structure config.
+        ScoringEvaluation: Proposal-aligned grouped energy and per-constraint
+            weighted contributions.
     """
     first_constraint = compiled_constraints[0].constraint
     config_model = execution_config
@@ -523,6 +528,7 @@ def evaluate_scoring_group(
     inputs = first_constraint.inputs
     num_proposals = inputs[0].num_proposals
     scores = [float("nan")] * num_proposals
+    constraint_scores = {compiled.constraint: [float("nan")] * num_proposals for compiled in compiled_constraints}
     loss_weights = _sum_weights_by_objective_key(
         (compiled.objective_key, compiled.constraint.weight) for compiled in compiled_constraints
     )
@@ -575,6 +581,7 @@ def evaluate_scoring_group(
         structures = af2_binder_structures(output.structure, config, len(inputs))
         for compiled in compiled_constraints:
             term_score = _term_score(output.metrics, compiled.objective_key, output.loss)
+            constraint_scores[compiled.constraint][proposal_idx] = compiled.constraint.weight * term_score
             metadata = af2_binder_constraint_output_metadata(
                 output.metrics,
                 output_loss=term_score,
@@ -594,7 +601,7 @@ def evaluate_scoring_group(
             if structure is not None:
                 seq.structure = structure
 
-    return scores
+    return ScoringEvaluation([scores], constraint_scores)
 
 
 def _provider_label(constraints: list[CompiledConstraint]) -> str:

--- a/proto_language/optimizer/constraint_compiler/base.py
+++ b/proto_language/optimizer/constraint_compiler/base.py
@@ -117,6 +117,22 @@ class CompiledConstraint:
 
 
 @dataclass(frozen=True)
+class ScoringEvaluation:
+    """Aggregate scoring components plus every public constraint contribution.
+
+    Attributes:
+        aggregate_scores (list[list[float]]): Proposal-aligned weighted vectors
+            consumed by the optimizer's energy aggregation. A compiled backend
+            group contributes one vector even when it contains several terms.
+        constraint_scores (dict[Constraint, list[float]]): Proposal-aligned
+            weighted contribution for every public constraint object.
+    """
+
+    aggregate_scores: list[list[float]]
+    constraint_scores: dict[Constraint, list[float]]
+
+
+@dataclass(frozen=True)
 class GradientProviderOutput:
     """Gradients and losses returned by a provider for one optimizer step.
 

--- a/proto_language/optimizer/constraint_compiler/compiler.py
+++ b/proto_language/optimizer/constraint_compiler/compiler.py
@@ -41,6 +41,7 @@ from proto_language.optimizer.constraint_compiler.base import (
     EffectiveWeight,
     GradientProvider,
     GradientProviderOutput,
+    ScoringEvaluation,
     clone_execution_config,
 )
 
@@ -89,8 +90,13 @@ class DirectGradientProvider(GradientProvider):
         Returns:
             GradientProviderOutput: Proposal-aligned target gradients and weighted losses.
         """
-        results = self.constraint.compute_gradient(temperature=temperature, soft=soft, hard=hard)
         weight = effective_weight(self.constraint, step)
+        results = self.constraint.compute_gradient(
+            temperature=temperature,
+            soft=soft,
+            hard=hard,
+            effective_weight=weight,
+        )
         return GradientProviderOutput(
             label=self.label,
             gradients=[
@@ -175,7 +181,7 @@ def evaluate_scoring_constraints(
     mask: list[bool],
     verbose: bool = False,
     seed: int | None = None,
-) -> list[list[float]]:
+) -> ScoringEvaluation:
     """Evaluate forward scoring constraints, grouping compatible backend calls.
 
     This is the forward, non-gradient counterpart to
@@ -200,9 +206,8 @@ def evaluate_scoring_constraints(
             scoring-group seed streams.
 
     Returns:
-        list[list[float]]: Weighted score arrays, one entry per scoring unit.
-            A scoring unit is either one direct public constraint or one
-            compiled backend group containing multiple public constraints.
+        ScoringEvaluation: Aggregate weighted vectors used for energy plus
+            weighted vectors for every public constraint.
     """
     return compile_scoring_plan(constraints, seed=seed).evaluate(mask=mask, verbose=verbose)
 
@@ -340,7 +345,7 @@ class CompilerAdapter:
         compile_gradient (GradientCompiler | None): Gradient provider builder.
         check_gradient (GradientChecker | None): Runtime gradient preflight.
         match_scoring (ScoringMatcher | None): Additive scoring group matcher.
-        evaluate_scoring (Callable[[list[CompiledConstraint], list[bool], Any], list[float]] | None): Grouped scoring evaluator.
+        evaluate_scoring (Callable[[list[CompiledConstraint], list[bool], Any], ScoringEvaluation] | None): Grouped scoring evaluator.
     """
 
     backend_id: str
@@ -349,7 +354,7 @@ class CompilerAdapter:
     compile_gradient: GradientCompiler | None
     check_gradient: GradientChecker | None
     match_scoring: ScoringMatcher | None
-    evaluate_scoring: Callable[[list[CompiledConstraint], list[bool], Any], list[float]] | None
+    evaluate_scoring: Callable[[list[CompiledConstraint], list[bool], Any], ScoringEvaluation] | None
 
 
 _ESMFOLD_RULE = GradientRule(
@@ -694,9 +699,10 @@ class _DirectScoringUnit:
 
     constraint: Constraint
 
-    def evaluate(self, *, mask: list[bool], verbose: bool) -> list[float]:
+    def evaluate(self, *, mask: list[bool], verbose: bool) -> ScoringEvaluation:
         """Evaluate the direct constraint and normalize numeric outputs."""
-        return [float(score) for score in self.constraint.evaluate(mask=mask, verbose=verbose)]
+        scores = [float(score) for score in self.constraint.evaluate(mask=mask, verbose=verbose)]
+        return ScoringEvaluation([scores], {self.constraint: scores})
 
 
 @dataclass
@@ -707,7 +713,7 @@ class _CompiledScoringUnit:
     constraints: list[CompiledConstraint]
     config: BaseModel
 
-    def evaluate(self, *, mask: list[bool], verbose: bool) -> list[float]:
+    def evaluate(self, *, mask: list[bool], verbose: bool) -> ScoringEvaluation:
         """Evaluate the group through its compiler adapter."""
         del verbose
         if self.adapter.evaluate_scoring is None:
@@ -721,9 +727,19 @@ class ScoringPlan:
 
     units: tuple[_DirectScoringUnit | _CompiledScoringUnit, ...]
 
-    def evaluate(self, *, mask: list[bool], verbose: bool = False) -> list[list[float]]:
+    def evaluate(self, *, mask: list[bool], verbose: bool = False) -> ScoringEvaluation:
         """Evaluate every direct or compiled unit in stable plan order."""
-        return [unit.evaluate(mask=mask, verbose=verbose) for unit in self.units]
+        aggregate_scores: list[list[float]] = []
+        constraint_scores: dict[Constraint, list[float]] = {}
+        for unit in self.units:
+            result = unit.evaluate(mask=mask, verbose=verbose)
+            aggregate_scores.extend(result.aggregate_scores)
+            duplicate_constraints = constraint_scores.keys() & result.constraint_scores.keys()
+            if duplicate_constraints:
+                labels = sorted(constraint.label for constraint in duplicate_constraints)
+                raise ValueError(f"Scoring plan contains duplicate constraint objects: {labels}")
+            constraint_scores.update(result.constraint_scores)
+        return ScoringEvaluation(aggregate_scores, constraint_scores)
 
 
 def compile_scoring_plan(constraints: list[Constraint], *, seed: int | None = None) -> ScoringPlan:

--- a/proto_language/optimizer/constraint_compiler/esmfold_provider.py
+++ b/proto_language/optimizer/constraint_compiler/esmfold_provider.py
@@ -37,6 +37,7 @@ from proto_language.optimizer.constraint_compiler.base import (
     EffectiveWeight,
     GradientProvider,
     GradientProviderOutput,
+    ScoringEvaluation,
     _sum_weights_by_objective_key,
     config_group_identity,
     raise_for_failed_tool_output,
@@ -86,8 +87,10 @@ class ESMFoldGradientProvider(GradientProvider):
         effective_weight: EffectiveWeight,
     ) -> GradientProviderOutput:
         """Run one weighted ESMFold backward pass per proposal."""
+        effective_weights = [effective_weight(compiled.constraint, step) for compiled in self.constraints]
         loss_weights = _sum_weights_by_objective_key(
-            (compiled.objective_key, effective_weight(compiled.constraint, step)) for compiled in self.constraints
+            (compiled.objective_key, weight)
+            for compiled, weight in zip(self.constraints, effective_weights, strict=True)
         )
         target_chain_indices = [idx for idx, segment in enumerate(self.inputs) if segment is self.target_segment]
         num_proposals = self.inputs[0].num_proposals
@@ -126,7 +129,7 @@ class ESMFoldGradientProvider(GradientProvider):
             gradients.append(np.array(output.gradient, dtype=np.float64))
             losses.append(output.loss)
 
-            for compiled in self.constraints:
+            for compiled, weight in zip(self.constraints, effective_weights, strict=True):
                 score = _term_score(output.metrics, compiled.objective_key, output.loss)
                 metadata = _constraint_metadata(
                     output.metrics,
@@ -135,7 +138,12 @@ class ESMFoldGradientProvider(GradientProvider):
                     output_loss=score,
                     group_loss=output.loss,
                 )
-                compiled.constraint._write_constraint_metadata(proposal_idx, score, metadata)
+                compiled.constraint._write_constraint_metadata(
+                    proposal_idx,
+                    score,
+                    metadata,
+                    effective_weight=weight,
+                )
 
             self.target_segment.proposal_sequences[proposal_idx].structure = output.structure
 
@@ -256,7 +264,7 @@ def evaluate_scoring_group(
     compiled_constraints: list[CompiledConstraint],
     mask: list[bool],
     execution_config: StructureBasedConstraintConfig,
-) -> list[float]:
+) -> ScoringEvaluation:
     """Evaluate compatible ESMFold confidence constraints with one prediction batch.
 
     ESMFold's prediction API can score all proposals in one backend call. This
@@ -270,9 +278,10 @@ def evaluate_scoring_group(
     inputs = first_constraint.inputs
     num_proposals = inputs[0].num_proposals
     scores = [float("nan")] * num_proposals
+    constraint_scores = {compiled.constraint: [float("nan")] * num_proposals for compiled in compiled_constraints}
     proposal_indices = [idx for idx, should_eval in enumerate(mask) if should_eval]
     if not proposal_indices:
-        return scores
+        return ScoringEvaluation([scores], constraint_scores)
 
     complexes = []
     for proposal_idx in proposal_indices:
@@ -298,6 +307,7 @@ def evaluate_scoring_group(
         scores[proposal_idx] = group_score
 
         for compiled, score in zip(compiled_constraints, term_scores, strict=True):
+            constraint_scores[compiled.constraint][proposal_idx] = compiled.constraint.weight * score
             metadata = _scoring_constraint_metadata(
                 metrics,
                 output_structure=structure,
@@ -309,7 +319,7 @@ def evaluate_scoring_group(
 
         inputs[0].proposal_sequences[proposal_idx].structure = structure
 
-    return scores
+    return ScoringEvaluation([scores], constraint_scores)
 
 
 def _proposal_chains(inputs: list[Segment], target_segment: Segment, proposal_idx: int) -> list[str]:

--- a/proto_language/optimizer/constraint_compiler/malinois_provider.py
+++ b/proto_language/optimizer/constraint_compiler/malinois_provider.py
@@ -34,6 +34,7 @@ from proto_language.optimizer.constraint_compiler.base import (
     EffectiveWeight,
     GradientProvider,
     GradientProviderOutput,
+    ScoringEvaluation,
     config_group_identity,
     raise_for_failed_tool_output,
 )
@@ -77,9 +78,10 @@ class MalinoisGradientProvider(GradientProvider):
                 raise RuntimeError(f"{self.label} proposal {proposal_idx}: target input is missing logits.")
             target_logits.append(target_seq.logits)
 
+        effective_weights = [effective_weight(compiled.constraint, step) for compiled in self.constraints]
         loss_terms = [
-            _gradient_loss_term(compiled.constraint, effective_weight(compiled.constraint, step))
-            for compiled in self.constraints
+            _gradient_loss_term(compiled.constraint, weight)
+            for compiled, weight in zip(self.constraints, effective_weights, strict=True)
         ]
         if all(term.weight == 0.0 for term in loss_terms):
             return GradientProviderOutput(
@@ -123,10 +125,20 @@ class MalinoisGradientProvider(GradientProvider):
             )
 
         for proposal_idx, term_metrics in enumerate(loss_terms_by_proposal):
-            for compiled, term_metric in zip(self.constraints, term_metrics, strict=True):
+            for compiled, term_metric, weight in zip(
+                self.constraints,
+                term_metrics,
+                effective_weights,
+                strict=True,
+            ):
                 score = float(term_metric["score"])
                 metadata = _metadata_from_term(term_metric, group_score=float(losses[proposal_idx]))
-                compiled.constraint._write_constraint_metadata(proposal_idx, score, metadata)
+                compiled.constraint._write_constraint_metadata(
+                    proposal_idx,
+                    score,
+                    metadata,
+                    effective_weight=weight,
+                )
 
         return GradientProviderOutput(label=self.label, gradients=gradients, losses=[float(loss) for loss in losses])
 
@@ -223,7 +235,7 @@ def evaluate_scoring_group(
     compiled_constraints: list[CompiledConstraint],
     mask: list[bool],
     execution_config: MalinoisActivityConfig,
-) -> list[float]:
+) -> ScoringEvaluation:
     """Evaluate compatible Malinois activity constraints with one prediction batch."""
     first_constraint = compiled_constraints[0].constraint
     config = execution_config
@@ -231,9 +243,10 @@ def evaluate_scoring_group(
     segment = first_constraint.inputs[0]
     num_proposals = segment.num_proposals
     scores = [float("nan")] * num_proposals
+    constraint_scores = {compiled.constraint: [float("nan")] * num_proposals for compiled in compiled_constraints}
     proposal_indices = [idx for idx, should_eval in enumerate(mask) if should_eval]
     if not proposal_indices:
-        return scores
+        return ScoringEvaluation([scores], constraint_scores)
 
     term_configs: list[MalinoisActivityConfig] = []
     for compiled in compiled_constraints:
@@ -287,13 +300,14 @@ def evaluate_scoring_group(
         scores[proposal_idx] = group_score
 
         for compiled, score, metadata in zip(compiled_constraints, term_scores, term_metadata, strict=True):
+            constraint_scores[compiled.constraint][proposal_idx] = compiled.constraint.weight * score
             compiled.constraint._write_constraint_metadata(
                 proposal_idx,
                 score,
                 _metadata_from_term(metadata, group_score=group_score),
             )
 
-    return scores
+    return ScoringEvaluation([scores], constraint_scores)
 
 
 def _gradient_loss_term(constraint: Constraint, weight: float) -> MalinoisGradientLossTerm:

--- a/proto_language/optimizer/constraint_compiler/protenix_provider.py
+++ b/proto_language/optimizer/constraint_compiler/protenix_provider.py
@@ -26,7 +26,11 @@ from proto_language.constraint.protein_structure.structure_constraint_config imp
     resolve_metric,
 )
 from proto_language.core import Constraint
-from proto_language.optimizer.constraint_compiler.base import CompiledConstraint, config_group_identity
+from proto_language.optimizer.constraint_compiler.base import (
+    CompiledConstraint,
+    ScoringEvaluation,
+    config_group_identity,
+)
 from proto_language.utils import MAX_ENERGY
 
 logger = logging.getLogger(__name__)
@@ -97,7 +101,7 @@ def evaluate_scoring_group(
     compiled_constraints: list[CompiledConstraint],
     mask: list[bool],
     execution_config: StructureBasedConstraintConfig,
-) -> list[float]:
+) -> ScoringEvaluation:
     """Evaluate compatible Protenix confidence constraints with one prediction batch."""
     first_constraint = compiled_constraints[0].constraint
     config = execution_config
@@ -105,9 +109,10 @@ def evaluate_scoring_group(
     inputs = first_constraint.inputs
     num_proposals = inputs[0].num_proposals
     scores = [float("nan")] * num_proposals
+    constraint_scores = {compiled.constraint: [float("nan")] * num_proposals for compiled in compiled_constraints}
     proposal_indices = [idx for idx, should_eval in enumerate(mask) if should_eval]
     if not proposal_indices:
-        return scores
+        return ScoringEvaluation([scores], constraint_scores)
 
     complexes = []
     for proposal_idx in proposal_indices:
@@ -133,6 +138,7 @@ def evaluate_scoring_group(
         scores[proposal_idx] = group_score
 
         for compiled, score in zip(compiled_constraints, term_scores, strict=True):
+            constraint_scores[compiled.constraint][proposal_idx] = compiled.constraint.weight * score
             metadata = _scoring_constraint_metadata(
                 metrics,
                 output_structure=structure,
@@ -144,7 +150,7 @@ def evaluate_scoring_group(
 
         inputs[0].proposal_sequences[proposal_idx].structure = structure
 
-    return scores
+    return ScoringEvaluation([scores], constraint_scores)
 
 
 def _scoring_constraint_metadata(

--- a/proto_language/utils/io.py
+++ b/proto_language/utils/io.py
@@ -296,7 +296,8 @@ def _flatten_constraint_columns(constraints: dict[str, dict[str, Any]], prefix: 
     """Flatten all constraint data with {prefix}{label}.{field} namespacing.
 
     Used by flatten_sequences, flatten_constructs, flatten_optimization.
-    Includes score, weight, weighted_score, all data fields, and multi-segment info.
+    Includes score, configured/effective weights, weighted_score, all data fields,
+    and multi-segment info.
 
     Args:
         constraints (dict[str, dict[str, Any]]): Dict mapping constraint labels to their data.
@@ -305,7 +306,7 @@ def _flatten_constraint_columns(constraints: dict[str, dict[str, Any]], prefix: 
     flat = {}
     for label, cdata in constraints.items():
         base = f"{prefix}{label}"
-        for key in ("score", "weight", "weighted_score"):
+        for key in ("score", "weight", "configured_weight", "effective_weight", "weighted_score"):
             if key in cdata:
                 flat[f"{base}.{key}"] = cdata[key]
         for key in ("input_segments", "position_in_inputs"):
@@ -355,7 +356,8 @@ def flatten_sequences(
 
     Columns:
         Fixed: result_idx, energy_score, construct, segment, sequence
-        Per constraint: {label}.score, {label}.weight, {label}.weighted_score,
+        Per constraint: {label}.score, {label}.weight,
+            {label}.configured_weight, {label}.effective_weight, {label}.weighted_score,
             {label}.{data_key}, and optionally {label}.input_segments,
             {label}.position_in_inputs
         Per generator: generator.{registry_key}.{field}
@@ -404,7 +406,7 @@ def flatten_constraints(
 
     Columns:
         Fixed: result_idx, energy_score, construct, sequence_type, segment, constraint
-        Standard: score, weight, weighted_score
+        Standard: score, weight, configured_weight, effective_weight, weighted_score
         Multi-segment (when applicable): input_segments, position_in_inputs
         Custom data: {key} un-prefixed; a key colliding with a column above is
             prefixed with ``data.`` to avoid overwriting it.
@@ -431,6 +433,9 @@ def flatten_constraints(
                         "weight": cdata.get("weight"),
                         "weighted_score": cdata.get("weighted_score"),
                     }
+                    for key in ("configured_weight", "effective_weight"):
+                        if key in cdata:
+                            row[key] = cdata[key]
                     for key in ("input_segments", "position_in_inputs"):
                         if key in cdata:
                             row[key] = _serialize_value(cdata[key])

--- a/tests/language_tests/constraint_tests/test_base_constraint.py
+++ b/tests/language_tests/constraint_tests/test_base_constraint.py
@@ -825,6 +825,8 @@ class TestConstraintGradientSupport:
         metadata = segment.proposal_sequences[0]._constraints_metadata["test_grad"]
         assert metadata["score"] == pytest.approx(1.0)  # mean(ones**2) = 1.0
         assert metadata["weight"] == 1.0
+        assert metadata["configured_weight"] == 1.0
+        assert metadata["effective_weight"] == 1.0
         assert metadata["data"]["temperature"] == 1.0
 
     def test_temperature_affects_gradient(self) -> None:

--- a/tests/language_tests/optimizer_tests/test_base_optimizer.py
+++ b/tests/language_tests/optimizer_tests/test_base_optimizer.py
@@ -575,6 +575,32 @@ class TestScoreEnergy:
         # Expected: [2*4, 3*5] = [8, 15]
         assert optimizer.energy_scores == [8.0, 15.0]
 
+    def test_duplicate_labels_on_different_segments_keep_separate_observability(self):
+        """Per-constraint scoring vectors use qualified labels when public labels repeat."""
+        segment_a = Segment(sequence="AA", sequence_type="dna")
+        segment_b = Segment(sequence="CC", sequence_type="dna")
+        construct = Construct([segment_a, segment_b])
+        generators = [MockGenerator(), MockGenerator()]
+        generators[0].assign(segment_a)
+        generators[1].assign(segment_b)
+        constraints = []
+        for segment, score in [(segment_a, 1.0), (segment_b, 2.0)]:
+            constraint = MagicMock(spec=Constraint)
+            constraint.inputs = [segment]
+            constraint.label = "shared"
+            constraint.weight = 1.0
+            constraint.threshold = None
+            constraint.evaluate.return_value = [score]
+            constraints.append(constraint)
+
+        optimizer = ConcreteOptimizer([construct], generators, constraints, 1, 1)
+        optimizer.score_energy()
+
+        assert optimizer.energy_scores == [3.0]
+        assert len(optimizer._last_constraint_scores) == 2
+        assert all(label.startswith("shared[") for label in optimizer._last_constraint_scores)
+        assert sorted(values[0] for values in optimizer._last_constraint_scores.values()) == [1.0, 2.0]
+
     def test_invalid_operation_raises_error(self):
         """Tests that invalid operation raises ValueError."""
         construct, generator, constraint, segment = _setup_optimizer_components()

--- a/tests/language_tests/optimizer_tests/test_gradient_optimizer.py
+++ b/tests/language_tests/optimizer_tests/test_gradient_optimizer.py
@@ -706,6 +706,7 @@ class TestWeightSchedules:
             num_steps=10,
             lr=1.0,
             normalize_gradients=False,
+            save_best=False,
             constraint_weight_schedules=[
                 ConstraintWeightSchedule(constraint_label="ablang", start_weight=0.0, end_weight=0.2)
             ],
@@ -714,6 +715,11 @@ class TestWeightSchedules:
         logits = seg.result_sequences[0].logits
         assert logits is not None
         assert logits.min() > -50.0
+        metadata = seg.result_sequences[0]._constraints_metadata["ablang"]
+        assert metadata["configured_weight"] == 99.0
+        assert metadata["effective_weight"] == pytest.approx(0.2)
+        assert metadata["weight"] == pytest.approx(0.2)
+        assert metadata["weighted_score"] == pytest.approx(metadata["score"] * 0.2)
 
     def test_missing_label_warns_but_runs(self, caplog: pytest.LogCaptureFixture) -> None:
         seg = Segment(sequence="AA", sequence_type="protein")
@@ -873,6 +879,13 @@ class TestCompiledConstraints:
                     num_steps=1,
                     lr=0.1,
                     normalize_gradients=False,
+                    constraint_weight_schedules=[
+                        ConstraintWeightSchedule(
+                            constraint_label="esmfold_plddt",
+                            start_weight=1.0,
+                            end_weight=1.0,
+                        )
+                    ],
                 ),
             )
             assert opt._gradient_providers == []
@@ -883,8 +896,11 @@ class TestCompiledConstraints:
         assert opt.energy_scores == [pytest.approx(3.0)]
         assert mock_esm.call_count == 1
         assert mock_esm.call_args.args[0].target_chain_indices == [0]
-        assert mock_esm.call_args.args[1].loss_weights == {"plddt": 2.0, "ptm": 0.5}
+        assert mock_esm.call_args.args[1].loss_weights == {"plddt": 1.0, "ptm": 0.5}
         assert {"esmfold_plddt", "esmfold_ptm"}.issubset(metadata)
+        assert metadata["esmfold_plddt"]["configured_weight"] == 2.0
+        assert metadata["esmfold_plddt"]["effective_weight"] == 1.0
+        assert metadata["esmfold_plddt"]["weighted_score"] == pytest.approx(0.2)
 
     def test_groups_esmfold_scoring_terms_into_one_prediction_call(self) -> None:
         from proto_language.optimizer.constraint_compiler import evaluate_scoring_constraints
@@ -901,7 +917,11 @@ class TestCompiledConstraints:
             mock_esm.return_value = SimpleNamespace(structures=[structure])
             scores = evaluate_scoring_constraints(constraints, mask=[True])
 
-        assert scores == [[pytest.approx(0.7)]]
+        assert scores.aggregate_scores == [[pytest.approx(0.7)]]
+        assert {constraint.label: values for constraint, values in scores.constraint_scores.items()} == {
+            "esmfold_plddt": [pytest.approx(0.4)],
+            "esmfold_ptm": [pytest.approx(0.3)],
+        }
         assert mock_esm.call_count == 1
         assert mock_esm.call_args.args[1] == "esmfold"
         metadata = binder.proposal_sequences[0]._constraints_metadata
@@ -927,7 +947,13 @@ class TestCompiledConstraints:
             scores = evaluate_scoring_constraints(constraints, mask=[True])
 
         expected = (2.0 * 0.2) + (0.5 * 0.6) + (3.0 * 0.3) + (4.0 * 0.2)
-        assert scores == [[pytest.approx(expected)]]
+        assert scores.aggregate_scores == [[pytest.approx(expected)]]
+        assert {constraint.label for constraint in scores.constraint_scores} == {
+            "protenix_plddt",
+            "protenix_ptm",
+            "protenix_iptm",
+            "protenix_pae",
+        }
         assert mock_protenix.call_count == 1
         assert mock_protenix.call_args.args[1] == "protenix"
         assert mock_protenix.call_args.args[2].seed == 0
@@ -977,7 +1003,11 @@ class TestCompiledConstraints:
             mock_protenix.return_value = SimpleNamespace(structures=[structure])
             scores = evaluate_scoring_constraints(constraints, mask=[True], seed=1234)
 
-        assert scores == [[pytest.approx(0.7)]]
+        assert scores.aggregate_scores == [[pytest.approx(0.7)]]
+        assert {constraint.label: values for constraint, values in scores.constraint_scores.items()} == {
+            "protenix_plddt": [pytest.approx(0.4)],
+            "protenix_ptm": [pytest.approx(0.3)],
+        }
         assert mock_protenix.call_count == 1
         execution_config = mock_protenix.call_args.args[2]
         assert execution_config.seed == execution_config.seeds[0]
@@ -1041,7 +1071,11 @@ class TestCompiledConstraints:
                 return_value=score_output,
             ) as mock_malinois:
                 scores = evaluate_scoring_constraints(constraints, mask=[True])
-            assert scores == [[pytest.approx(tool_loss, rel=1e-5)]]
+            assert scores.aggregate_scores == [[pytest.approx(tool_loss, rel=1e-5)]]
+            assert {constraint.label for constraint in scores.constraint_scores} == {
+                "malinois_k562_max",
+                "malinois_hepg2_min",
+            }
             assert mock_malinois.call_count == 1
             assert mock_malinois.call_args.args[1].cell_types == ["K562", "HepG2"]
             metadata = enhancer.proposal_sequences[0]._constraints_metadata
@@ -1198,7 +1232,7 @@ class TestCompiledConstraints:
                 metadata = binder.result_sequences[0]._constraints_metadata
             else:
                 scores = evaluate_scoring_constraints(constraints, mask=[True])
-                assert scores == [[tool_loss]]
+                assert scores.aggregate_scores == [[tool_loss]]
                 metadata = binder.proposal_sequences[0]._constraints_metadata
 
         assert mock_af2.call_count == 1
@@ -1263,7 +1297,7 @@ class TestCompiledConstraints:
                 opt.run()
             else:
                 scores = evaluate_scoring_constraints(constraints, mask=[True])
-                assert scores == [[pytest.approx(3.5)]]
+                assert scores.aggregate_scores == [[pytest.approx(3.5)]]
 
         assert mock_af2.call_count == 1
         assert mock_af2.call_args[0][0].target_pdb.source == str(first_path)
@@ -1320,6 +1354,10 @@ class TestCompiledConstraints:
             opt.score_energy()
 
         assert opt.energy_scores == [pytest.approx(4.0)]
+        assert opt._last_constraint_scores == {
+            "af2_plddt": [pytest.approx(2.0)],
+            "af2_ipae": [pytest.approx(1.0)],
+        }
         assert mock_af2.call_count == 1
         assert mock_af2.call_args[0][1].loss_weights == {
             "plddt": 2.0,
@@ -1361,7 +1399,8 @@ class TestCompiledConstraints:
 
         scores = evaluate_scoring_constraints([constraint], mask=[True])
 
-        assert scores == [[0.0]]
+        assert scores.aggregate_scores == [[0.0]]
+        assert scores.constraint_scores == {constraint: [0.0]}
 
     def test_af2_config_parse_is_strict_only_when_requested(self) -> None:
         """Compiler probes can be lenient, while execution paths preserve validation errors."""


### PR DESCRIPTION
## Summary

- Return both aggregate component vectors used for energy and weighted contribution vectors for each public constraint.
- Keep backend-returned grouped losses as the optimization source of truth while restoring per-term progress visibility.
- Qualify duplicate public labels on different segments so their metrics remain distinct.
- Record configured and effective runtime weights in metadata, with legacy `weight` and `weighted_score` reflecting the applied schedule.
- Surface the new metadata fields through result flattening.

## Architectural issue

Grouping multiple public constraints into one backend call preserved performance but collapsed observability into a single aggregate. Scheduled gradient objectives also reported configured rather than effective weights. This made progress logs and exported metadata diverge from the objective the optimizer actually used.

## Validation

- `pytest --cpu-only -q --override-ini="log_cli=false"`: 3,968 passed, 254 expected skips
- `ruff check proto_language tests`: passed
- `ruff format --check`: passed
- `mypy proto_language/`: passed
- `python .github/scripts/validate_exports.py --verbose`: passed

## Stack

Stack 5 of 6. Base: `fix/compiler-seed-lifecycle`. Next: `fix/constraint-input-pool-membership`.