### PR TITLE
Require constraint inputs to belong to optimizer constructs

### DIFF
--- a/notes/batching.md
+++ b/notes/batching.md
@@ -10,6 +10,13 @@ Batching is split across proposal pools, generators, constraint calls, compiled 
 4. **Compiled scorers can group compatible constraints.** Additive scoring routes through the constraint compiler, which may collapse several public constraints into one backend call.
 5. **Tools own backend memory strategy.** Sequence count is only one dimension; structures, chains, ligands, recycles, MSA depth, and sample count often matter more.
 
+Every constraint input must be the exact `Segment` instance owned by one of the
+optimizer's constructs. This keeps all consumed proposal pools inside the same
+explicit lifecycle. Fixed context segments do not need a generator, but they
+must be included in a construct and populated before optimizer construction.
+Constraints may combine segments from different constructs passed to the same
+optimizer, and may repeat one owned segment for homo-oligomer inputs.
+
 ## Optimizer Proposal Batching
 
 `Generator` defines the shared fallback:

--- a/proto_language/core/optimizer.py
+++ b/proto_language/core/optimizer.py
@@ -477,7 +477,8 @@ class Optimizer(ABC):
             3. Structure validation: Constructs have segments, generators/constraints are assigned.
             4. No duplicate instances: Each generator/constraint instance can only appear once.
             5. Unique constraint labels: Required for metadata namespacing.
-            6. Valid constraint inputs: Constraints can only reference populated segments.
+            6. Valid constraint inputs: Constraints can only reference construct-owned
+               segments that are populated or assigned to a generator.
             7. Component compatibility: Optimizer/generator/constraint declarative
                dependencies hold (via ``_validate_component_compatibility()``).
 
@@ -555,7 +556,20 @@ class Optimizer(ABC):
         self._deduplicate_constraint_labels()
 
         # 6. Valid constraint inputs
-        # Constraints can only reference segments that have sequences or a generator assigned.
+        # Constraint inputs must belong to this optimizer's constructs so their proposal
+        # pools share one explicit lifecycle. Membership is identity-based because the
+        # exact Segment object owns the mutable pools consumed by constraints.
+        construct_segment_ids = {id(segment) for segment in self.segments}
+        for constraint in self.constraints:
+            for input_index, segment in enumerate(constraint.inputs):
+                if id(segment) not in construct_segment_ids:
+                    raise ValueError(
+                        f"Constraint '{constraint.label}' input {input_index} references segment "
+                        f"'{segment.label or 'unlabeled'}', which does not belong to an optimizer construct. "
+                        "Add the segment to a Construct passed to this optimizer."
+                    )
+
+        # Construct-owned inputs must have sequences or a generator assigned.
         allow_unpopulated_score_only_inputs = (
             not self.generators and self._allow_unpopulated_constraint_inputs_without_generators
         )

--- a/tests/language_tests/optimizer_tests/test_base_optimizer.py
+++ b/tests/language_tests/optimizer_tests/test_base_optimizer.py
@@ -266,6 +266,34 @@ class TestOptimizerValidation:
         ConcreteOptimizer([construct], [generator1, generator2], [constraint1, constraint2], 4, 2)
 
     # 6. Valid constraint inputs
+    def test_constraint_references_populated_external_segment_raises(self):
+        """Reject populated constraint inputs outside the optimizer constructs."""
+        construct, generator, _, _segment = _setup_optimizer_components()
+        external_segment = Segment(sequence="GCTA", sequence_type="dna")
+
+        constraint = MagicMock(spec=Constraint)
+        constraint.inputs = [external_segment]
+        constraint.label = "external_constraint"
+        constraint.threshold = None
+        constraint.weight = 1.0
+
+        with pytest.raises(ValueError, match="does not belong to an optimizer construct"):
+            ConcreteOptimizer([construct], [generator], [constraint], 4, 2)
+
+    def test_constraint_references_unpopulated_external_segment_raises(self):
+        """Reject unpopulated external inputs before checking proposal state."""
+        construct, generator, _, _segment = _setup_optimizer_components()
+        external_segment = Segment(sequence_type="dna", length=4)
+
+        constraint = MagicMock(spec=Constraint)
+        constraint.inputs = [external_segment]
+        constraint.label = "external_constraint"
+        constraint.threshold = None
+        constraint.weight = 1.0
+
+        with pytest.raises(ValueError, match="does not belong to an optimizer construct"):
+            ConcreteOptimizer([construct], [generator], [constraint], 4, 2)
+
     def test_constraint_references_unpopulated_segment_raises(self):
         """Tests that constraint referencing unpopulated segment without generator raises."""
         segment_with_gen = Segment(sequence="ATCG", sequence_type="dna")
@@ -283,6 +311,47 @@ class TestOptimizerValidation:
 
         with pytest.raises(RuntimeError, match="no populated sequence and no generator assigned"):
             ConcreteOptimizer([construct], [generator], [constraint], 4, 2)
+
+    def test_constraint_accepts_fixed_context_segment_in_construct(self):
+        """Accept a fixed context input owned by a construct without a generator."""
+        designed_segment = Segment(sequence="ATCG", sequence_type="dna")
+        context_segment = Segment(sequence="GCTA", sequence_type="dna")
+        construct = Construct([designed_segment, context_segment])
+
+        generator = MockGenerator()
+        generator.assign(designed_segment)
+
+        constraint = MagicMock(spec=Constraint)
+        constraint.inputs = [designed_segment, context_segment]
+        constraint.label = "context_constraint"
+        constraint.threshold = None
+        constraint.weight = 1.0
+
+        ConcreteOptimizer([construct], [generator], [constraint], 4, 2)
+
+    def test_constraint_accepts_segment_from_another_optimizer_construct(self):
+        """Accept inputs owned by any construct in the same optimizer."""
+        designed_segment = Segment(sequence="ATCG", sequence_type="dna")
+        context_segment = Segment(sequence="GCTA", sequence_type="dna")
+        designed_construct = Construct([designed_segment])
+        context_construct = Construct([context_segment])
+
+        generator = MockGenerator()
+        generator.assign(designed_segment)
+
+        constraint = MagicMock(spec=Constraint)
+        constraint.inputs = [designed_segment, context_segment]
+        constraint.label = "cross_construct_constraint"
+        constraint.threshold = None
+        constraint.weight = 1.0
+
+        ConcreteOptimizer(
+            [designed_construct, context_construct],
+            [generator],
+            [constraint],
+            4,
+            2,
+        )
 
     # 7. Homo-oligomer constraints (same segment repeated in inputs)
     def test_homo_oligomer_constraint_same_segment_multiple_times(self):


### PR DESCRIPTION
## Summary

- Require every constraint input to be the exact `Segment` instance owned by one of the optimizer's constructs.
- Fail during optimizer validation before proposal-pool initialization when an external segment is referenced.
- Preserve supported fixed context segments, cross-construct inputs within one optimizer, and repeated homo-oligomer aliases.
- Document the proposal-pool ownership contract.

## Architectural issue

A populated external segment previously passed validation even though its proposal pool was outside the optimizer's lifecycle. Constraints could therefore consume state that generation, handoff, filtering, and result export did not own consistently. Identity-based construct membership makes pool ownership explicit without preventing fixed context or multi-construct scoring.

## Validation

- `pytest --cpu-only -q --override-ini="log_cli=false"`: 3,968 passed, 254 expected skips
- `ruff check proto_language tests`: passed
- `ruff format --check`: passed
- `mypy proto_language/`: passed
- `python .github/scripts/validate_exports.py --verbose`: passed

## Stack

Stack 6 of 6. Base: `fix/compiled-scoring-observability`.